### PR TITLE
Add student search to dashboard

### DIFF
--- a/backend/routes/users/alunos.js
+++ b/backend/routes/users/alunos.js
@@ -29,7 +29,7 @@ router.post('/alunos', verifyToken, async (req, res) => {
 
 // Listar alunos
 router.get('/alunos', verifyToken, async (req, res) => {
-    const personalId = req.user;
+    const personalId = req.user.uid;
 
     try {
         const snapshot = await admin.firestore()
@@ -38,10 +38,16 @@ router.get('/alunos', verifyToken, async (req, res) => {
             .collection('alunos')
             .get();
 
-        const alunos = snapshot.docs.map(doc => ({
+        let alunos = snapshot.docs.map(doc => ({
             id: doc.id,
             ...doc.data()
         }));
+
+        const { nome } = req.query;
+        if (nome) {
+            const search = nome.toLowerCase();
+            alunos = alunos.filter(aluno => aluno.nome && aluno.nome.toLowerCase().includes(search));
+        }
 
         res.status(200).json(alunos);
     } catch (err) {

--- a/frontend/js/alunos.js
+++ b/frontend/js/alunos.js
@@ -10,12 +10,23 @@ export async function loadAlunosSection() {
 
         content.innerHTML = `
             <h2>Meus Alunos</h2>
-            <ul>
+            <input type="text" id="searchAluno" placeholder="Buscar por nome..." />
+            <ul id="alunoList">
                 ${alunos.map(aluno => `
                     <li><strong>${aluno.nome}</strong> (${aluno.email})</li>
                 `).join('')}
             </ul>
         `;
+
+        const searchInput = document.getElementById('searchAluno');
+        const list = document.getElementById('alunoList');
+        searchInput.addEventListener('input', () => {
+            const term = searchInput.value.toLowerCase();
+            list.innerHTML = alunos
+                .filter(a => a.nome && a.nome.toLowerCase().includes(term))
+                .map(aluno => `<li><strong>${aluno.nome}</strong> (${aluno.email})</li>`)
+                .join('');
+        });
     } catch (err) {
         console.error("Erro ao buscar alunos:", err);
         content.innerHTML = `<p style="color:red;">Erro ao carregar alunos</p>`;


### PR DESCRIPTION
## Summary
- fix route for fetching students
- allow filtering students by name on the backend
- include search input and client-side filtering on the dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844a98aa70483239fbc329eb5890721