### PR TITLE
Fix register toggling and admin invite

### DIFF
--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -9,6 +9,7 @@ router.use('/users', require('./users/profile'));
 router.use('/users', require('./users/treinos'));
 router.use('/users', require('./users/exercicios'));
 router.use('/users', require('./users/metodos'));
+router.use('/users', require('./users/admin-invite'));
 
 
 module.exports = router;

--- a/backend/routes/users/admin-invite.js
+++ b/backend/routes/users/admin-invite.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const router = express.Router();
+const admin = require('../../firebase-admin');
+const verifyToken = require('../../middleware/verifyToken');
+
+router.post('/admin-invites', verifyToken, async (req, res) => {
+    try {
+        const userDoc = await admin.firestore().collection('users').doc(req.user.uid).get();
+        if (!userDoc.exists || userDoc.data().role !== 'admin') {
+            return res.status(403).json({ message: 'Apenas admins podem criar convites' });
+        }
+
+        const code = Math.random().toString(36).substring(2, 8);
+        await admin.firestore().collection('adminInvites').doc(code).set({
+            createdBy: req.user.uid,
+            createdAt: new Date().toISOString(),
+            used: false
+        });
+
+        res.status(200).json({ code });
+    } catch (err) {
+        console.error('Erro ao criar convite de admin:', err);
+        res.status(500).json({ message: 'Erro ao criar convite de admin' });
+    }
+});
+
+module.exports = router;

--- a/backend/routes/users/register.js
+++ b/backend/routes/users/register.js
@@ -31,7 +31,12 @@ router.post('/register', verifyToken, async (req, res) => {
         }
 
         if (tipo === 'admin') {
-            if (!codigo || codigo !== 'admin123') {
+            if (!codigo) {
+                return res.status(403).json({ message: 'Código de admin obrigatório' });
+            }
+
+            const inviteDoc = await admin.firestore().collection('adminInvites').doc(codigo).get();
+            if (!inviteDoc.exists || inviteDoc.data().used) {
                 return res.status(403).json({ message: 'Código de admin inválido' });
             }
 
@@ -41,6 +46,8 @@ router.post('/register', verifyToken, async (req, res) => {
                 role: 'admin',
                 createdAt: new Date().toISOString()
             });
+
+            await inviteDoc.ref.update({ used: true, usedBy: uid, usedAt: new Date().toISOString() });
 
             return res.status(200).json({ message: 'Admin registrado' });
         }

--- a/frontend/js/register.js
+++ b/frontend/js/register.js
@@ -1,0 +1,58 @@
+import { auth } from './firebase-config.js';
+import { createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js";
+
+const btnAluno = document.getElementById('btnAluno');
+const btnPersonal = document.getElementById('btnPersonal');
+const personalFields = document.getElementById('personalFields');
+let selectedType = 'aluno';
+
+if (btnAluno && btnPersonal) {
+    btnAluno.addEventListener('click', () => {
+        selectedType = 'aluno';
+        btnAluno.classList.add('active');
+        btnPersonal.classList.remove('active');
+        if (personalFields) personalFields.classList.add('hidden');
+    });
+
+    btnPersonal.addEventListener('click', () => {
+        selectedType = 'personal';
+        btnPersonal.classList.add('active');
+        btnAluno.classList.remove('active');
+        if (personalFields) personalFields.classList.remove('hidden');
+    });
+}
+
+const registerForm = document.getElementById('registerForm');
+if (registerForm) {
+    registerForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const email = e.target.email.value;
+        const password = e.target.password.value;
+        const username = e.target.username ? e.target.username.value : '';
+        const codigo = e.target.codigo ? e.target.codigo.value : '';
+
+        try {
+            const cred = await createUserWithEmailAndPassword(auth, email, password);
+            const token = await cred.user.getIdToken();
+
+            const res = await fetch('http://localhost:3000/users/register', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`
+                },
+                body: JSON.stringify({ email, username, tipo: selectedType, codigo })
+            });
+
+            if (!res.ok) {
+                const data = await res.json();
+                throw new Error(data.message || 'Falha no registro');
+            }
+
+            alert('Conta criada com sucesso!');
+            window.location.href = 'login.html';
+        } catch (err) {
+            alert('Erro ao registrar: ' + err.message);
+        }
+    });
+}

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -37,6 +37,7 @@
     </div>
 
     <script type="module" src="./js/auth.js"></script>
+    <script type="module" src="./js/register.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- allow admins to create invitation codes
- check the invitation on admin registration
- add client-side script for register page to toggle user type and send data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844c67f9e4c832388f4b98edbca0002