### PR TITLE
Update exercises and methods creation fields

### DIFF
--- a/backend/routes/users/exercicios.js
+++ b/backend/routes/users/exercicios.js
@@ -6,7 +6,7 @@ const verifyToken = require('../../middleware/verifyToken');
 // Criar exercício personalizado
 router.post('/exercicios', verifyToken, async (req, res) => {
     const personalId = req.user.uid;
-    const { nome, categoria, seriesPadrao, repeticoesPadrao } = req.body;
+    const { nome, categoria, grupoMuscularPrincipal, gruposMusculares } = req.body;
 
     if (!nome) {
         return res.status(400).json({ error: 'Nome é obrigatório' });
@@ -23,8 +23,8 @@ router.post('/exercicios', verifyToken, async (req, res) => {
         const docRef = await collectionRef.add({
             nome,
             categoria: categoria || null,
-            seriesPadrao: seriesPadrao !== undefined ? Number(seriesPadrao) : null,
-            repeticoesPadrao: repeticoesPadrao !== undefined ? Number(repeticoesPadrao) : null,
+            grupoMuscularPrincipal: grupoMuscularPrincipal || null,
+            gruposMusculares: Array.isArray(gruposMusculares) ? gruposMusculares : [],
             criadoEm: new Date().toISOString()
         });
 

--- a/backend/routes/users/metodos.js
+++ b/backend/routes/users/metodos.js
@@ -6,7 +6,7 @@ const verifyToken = require('../../middleware/verifyToken');
 // Criar método de treino
 router.post('/metodos', verifyToken, async (req, res) => {
     const personalId = req.user.uid;
-    const { nome, series, repeticoes } = req.body;
+    const { nome, series, repeticoes, observacoes } = req.body;
 
     if (!nome) {
         return res.status(400).json({ error: 'Nome é obrigatório' });
@@ -24,6 +24,7 @@ router.post('/metodos', verifyToken, async (req, res) => {
             nome,
             series: series !== undefined ? Number(series) : null,
             repeticoes: repeticoes !== undefined ? Number(repeticoes) : null,
+            observacoes: observacoes || '',
             criadoEm: new Date().toISOString()
         });
 

--- a/frontend/js/exercicios.js
+++ b/frontend/js/exercicios.js
@@ -19,21 +19,46 @@ export async function loadExerciciosSection() {
 }
 
 function renderForms(container, exercicios, metodos) {
+    const exerciciosOptions = exercicios.map(e => `<option value="${e.nome}"></option>`).join('');
     container.innerHTML = `
         <h2>Exercícios Personalizados</h2>
         <form id="novoExercicio">
-            <input type="text" name="nome" placeholder="Nome" required />
-            <input type="text" name="categoria" placeholder="Categoria" />
-            <input type="number" name="seriesPadrao" placeholder="Séries padrão(opcional)" />
-            <input type="number" name="repeticoesPadrao" placeholder="Repetições padrão(opcional)" />
+            <input type="text" name="nome" list="exerciciosOptions" placeholder="Nome" required />
+            <datalist id="exerciciosOptions">${exerciciosOptions}</datalist>
+            <select name="categoria">
+                <option value="Musculação">Musculação</option>
+                <option value="Cardio">Cardio</option>
+                <option value="Mobilidade">Mobilidade</option>
+                <option value="Alongamento">Alongamento</option>
+            </select>
+            <select name="grupos" multiple>
+                <option value="Peito">Peito</option>
+                <option value="Costas">Costas</option>
+                <option value="Bíceps">Bíceps</option>
+                <option value="Tríceps">Tríceps</option>
+                <option value="Ombros">Ombros</option>
+                <option value="Pernas">Pernas</option>
+                <option value="Abdômen">Abdômen</option>
+                <option value="Glúteos">Glúteos</option>
+            </select>
+            <select name="grupoPrincipal">
+                <option value="Peito">Peito</option>
+                <option value="Costas">Costas</option>
+                <option value="Bíceps">Bíceps</option>
+                <option value="Tríceps">Tríceps</option>
+                <option value="Ombros">Ombros</option>
+                <option value="Pernas">Pernas</option>
+                <option value="Abdômen">Abdômen</option>
+                <option value="Glúteos">Glúteos</option>
+            </select>
             <button type="submit">Criar</button>
         </form>
-        <ul id="listaExercicios">${exercicios.map(e => `<li>${e.nome}</li>`).join('')}</ul>
         <h2>Métodos de Treino</h2>
         <form id="novoMetodo">
             <input type="text" name="nome" placeholder="Nome" required />
             <input type="number" name="series" placeholder="Séries" />
             <input type="number" name="repeticoes" placeholder="Repetições" />
+            <input type="text" name="observacoes" placeholder="Observações" />
             <button type="submit">Criar</button>
         </form>
         <ul id="listaMetodos">${metodos.map(m => `<li>${m.nome}</li>`).join('')}</ul>
@@ -42,11 +67,12 @@ function renderForms(container, exercicios, metodos) {
     document.getElementById('novoExercicio').addEventListener('submit', async e => {
         e.preventDefault();
         const form = e.target;
+        const grupos = Array.from(form.grupos.selectedOptions).map(o => o.value);
         const body = {
             nome: form.nome.value,
             categoria: form.categoria.value,
-            seriesPadrao: form.seriesPadrao.value,
-            repeticoesPadrao: form.repeticoesPadrao.value
+            grupoMuscularPrincipal: form.grupoPrincipal.value,
+            gruposMusculares: grupos
         };
         const resp = await fetchWithFreshToken('http://localhost:3000/users/exercicios', {
             method: 'POST',
@@ -66,7 +92,8 @@ function renderForms(container, exercicios, metodos) {
         const body = {
             nome: form.nome.value,
             series: form.series.value,
-            repeticoes: form.repeticoes.value
+            repeticoes: form.repeticoes.value,
+            observacoes: form.observacoes.value
         };
         const resp = await fetchWithFreshToken('http://localhost:3000/users/metodos', {
             method: 'POST',


### PR DESCRIPTION
## Summary
- extend method creation to store `observacoes`
- revamp exercise creation form
  - suggest existing exercises via datalist
  - predefined categories
  - muscle groups with principal choice
- remove default series/repetition fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844ccdc153c83239809fffcff119657