### PR TITLE
Fix método observação e layout

### DIFF
--- a/frontend/css/dashboard.css
+++ b/frontend/css/dashboard.css
@@ -113,6 +113,11 @@
     gap: 10px;
 }
 
+#novoTreinoForm h3 {
+    margin: 10px 0 5px;
+    color: #f58725;
+}
+
 .dia {
     background-color: #1e1e1e;
     padding: 15px;

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -111,3 +111,21 @@ button:hover {
 .hidden {
     display: none;
 }
+
+/* ===== SELECTS ===== */
+select {
+    width: 100%;
+    padding: 10px;
+    margin: 10px 0;
+    border-radius: 6px;
+    border: 1px solid #333;
+    background-color: #2a2a2a;
+    color: #fff;
+    box-sizing: border-box;
+}
+
+select:focus {
+    border-color: #f58725;
+    outline: none;
+    background-color: #2e2e2e;
+}

--- a/frontend/js/treinos.js
+++ b/frontend/js/treinos.js
@@ -21,10 +21,12 @@ export async function loadTreinosSection() {
         content.innerHTML = `
             <h2>Novo Treino</h2>
             <form id="novoTreinoForm">
+                <h3>Aluno</h3>
                 <select name="aluno" required>
                     <option value="">Selecione o aluno</option>
                     ${alunos.map(a => `<option value="${a.id}">${a.nome}</option>`).join('')}
                 </select>
+                <h3>Nome da ficha</h3>
                 <input type="text" name="nome" placeholder="Nome da ficha" required />
                 <div id="diasContainer"></div>
                 <button type="button" id="addDia">Adicionar Dia</button>
@@ -107,7 +109,7 @@ function addExercicio(container, catOptions) {
         <select class="nomeExercicio">${allOptions}</select>
         <select class="metodo">
             <option value="">Método</option>
-            ${METODOS.map(m => `<option value="${m.series || ''}|${m.repeticoes || ''}">${m.nome}</option>`).join('')}
+            ${METODOS.map(m => `<option data-series="${m.series || ''}" data-repeticoes="${m.repeticoes || ''}" data-observacoes="${m.observacoes || ''}">${m.nome}</option>`).join('')}
         </select>
         <input type="number" class="series" placeholder="Séries" />
         <input type="number" class="repeticoes" placeholder="Reps" />
@@ -122,6 +124,7 @@ function addExercicio(container, catOptions) {
     const metodoSel = exDiv.querySelector('.metodo');
     const seriesInput = exDiv.querySelector('.series');
     const repInput = exDiv.querySelector('.repeticoes');
+    const obsInput = exDiv.querySelector('.observacoes');
 
     categoriaSel.addEventListener('change', () => {
         const cat = categoriaSel.value;
@@ -130,9 +133,14 @@ function addExercicio(container, catOptions) {
     });
 
     metodoSel.addEventListener('change', () => {
-        const [s, r] = metodoSel.value.split('|');
+        const opt = metodoSel.selectedOptions[0];
+        if (!opt) return;
+        const s = opt.dataset.series;
+        const r = opt.dataset.repeticoes;
+        const o = opt.dataset.observacoes;
         if (s) seriesInput.value = s;
         if (r) repInput.value = r;
+        if (o) obsInput.value = o;
     });
 
     exDiv.querySelector('.removeExercicio').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add `h3` labels and tweak new treino creation form
- autofill observação field when método is selected
- style selects consistently
- style `h3` titles in treino form

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844cfbbbe408323bcae65ff778a07ad