### PR TITLE
Add edit/delete for exercises/methods and filters

### DIFF
--- a/frontend/css/dashboard.css
+++ b/frontend/css/dashboard.css
@@ -157,6 +157,11 @@
     color: #000;
 }
 
+.exercicio select.nomeExercicio,
+.exercicio input.observacoes {
+    grid-column: span 2;
+}
+
 .treino {
     background-color: #1e1e1e;
     padding: 15px;


### PR DESCRIPTION
## Summary
- allow updating and removing exercises and methods on the backend
- filter exercises by categoria and grupo muscular
- support editing/deleting from the exercises page with search filters
- enlarge exercise name and observation fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844e0be0dbc8323b9eb21dc741571a9