### PR TITLE
Add bulk exercise insertion script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "bulk:exercicios": "node scripts/inserir-exercicios.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/exercicios.json
+++ b/backend/scripts/exercicios.json
@@ -1,0 +1,20 @@
+[
+  {
+    "nome": "Agachamento Livre",
+    "categoria": "Musculacao",
+    "grupoMuscularPrincipal": "Quadriceps",
+    "gruposMusculares": ["Gluteos", "Posteriores"]
+  },
+  {
+    "nome": "Puxada na Frente",
+    "categoria": "Musculacao",
+    "grupoMuscularPrincipal": "Costas",
+    "gruposMusculares": ["Biceps"]
+  },
+  {
+    "nome": "Desenvolvimento com Halteres",
+    "categoria": "Musculacao",
+    "grupoMuscularPrincipal": "Ombros",
+    "gruposMusculares": ["Triceps"]
+  }
+]

--- a/backend/scripts/inserir-exercicios.js
+++ b/backend/scripts/inserir-exercicios.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const admin = require('../firebase-admin');
+
+async function main() {
+  const filePath = path.join(__dirname, 'exercicios.json');
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const exercicios = JSON.parse(raw);
+
+  if (!Array.isArray(exercicios)) {
+    throw new Error('exercicios.json deve conter um array de exercicios');
+  }
+
+  const db = admin.firestore();
+  const batch = db.batch();
+
+  exercicios.forEach(ex => {
+    const docRef = db.collection('exerciciosSistema').doc();
+    batch.set(docRef, {
+      nome: ex.nome,
+      categoria: ex.categoria || null,
+      grupoMuscularPrincipal: ex.grupoMuscularPrincipal || null,
+      gruposMusculares: Array.isArray(ex.gruposMusculares) ? ex.gruposMusculares : [],
+      criadoEm: new Date().toISOString()
+    });
+  });
+
+  await batch.commit();
+  console.log(`Inseridos ${exercicios.length} exercicios`);
+}
+
+main().then(() => process.exit()).catch(err => {
+  console.error('Erro ao inserir exercicios:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `scripts/inserir-exercicios.js` to bulk insert exercises into Firestore
- include example `exercicios.json` dataset
- expose script via new npm command `bulk:exercicios`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844e7f7432c832390ebd0f2b4e2aa63