### PR TITLE
Add treino management and UI improvements

### DIFF
--- a/backend/routes/users/treinos.js
+++ b/backend/routes/users/treinos.js
@@ -46,6 +46,49 @@ router.get('/alunos/:alunoId/treinos', verifyToken, async (req, res) => {
     }
 });
 
+// Atualizar treino de um aluno
+router.put('/alunos/:alunoId/treinos/:id', verifyToken, async (req, res) => {
+    const personalId = req.user.uid;
+    const { alunoId, id } = req.params;
+    const { nome, dias } = req.body;
+
+    const updateData = {};
+    if (nome !== undefined) updateData.nome = nome;
+    if (dias !== undefined) updateData.dias = Array.isArray(dias) ? dias : [];
+
+    try {
+        const docRef = admin.firestore()
+            .collection('users').doc(personalId)
+            .collection('alunos').doc(alunoId)
+            .collection('treinos').doc(id);
+
+        await docRef.update(updateData);
+        res.json({ message: 'Treino atualizado' });
+    } catch (err) {
+        console.error('Erro ao atualizar treino:', err);
+        res.status(500).json({ error: 'Erro ao atualizar treino' });
+    }
+});
+
+// Remover treino de um aluno
+router.delete('/alunos/:alunoId/treinos/:id', verifyToken, async (req, res) => {
+    const personalId = req.user.uid;
+    const { alunoId, id } = req.params;
+
+    try {
+        await admin.firestore()
+            .collection('users').doc(personalId)
+            .collection('alunos').doc(alunoId)
+            .collection('treinos').doc(id)
+            .delete();
+
+        res.json({ message: 'Treino removido' });
+    } catch (err) {
+        console.error('Erro ao remover treino:', err);
+        res.status(500).json({ error: 'Erro ao remover treino' });
+    }
+});
+
 // Listar treinos do aluno logado
 router.get('/me/treinos', verifyToken, async (req, res) => {
     const email = req.user.email;

--- a/frontend/css/dashboard.css
+++ b/frontend/css/dashboard.css
@@ -162,14 +162,18 @@
     grid-column: span 2;
 }
 
-.treino {
+.treinoCard {
     background-color: #1e1e1e;
     padding: 15px;
     border-radius: 6px;
     margin-bottom: 15px;
 }
 
-.treino ul {
+.diaCard {
+    margin-top: 10px;
+}
+
+.diaCard ul {
     list-style: none;
     padding-left: 20px;
 }

--- a/frontend/js/exercicios.js
+++ b/frontend/js/exercicios.js
@@ -7,7 +7,7 @@ const CATEGORIAS = [
     'Alongamento'
 ];
 
-const GRUPOS = [
+export const GRUPOS = [
     'Peito',
     'Costas',
     'Bíceps',


### PR DESCRIPTION
## Summary
- export muscle group list from exercicios module
- sort categories and exercises when building treino form
- add group filter and alphabetical options when selecting exercises
- allow personals to view, edit and delete a student's treinos
- implement backend update/delete routes for treinos
- restyle treino cards for students

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844ed4150b08323ac6e809027f32af9