### PR TITLE
Implement anamnese form and backend

### DIFF
--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -10,6 +10,7 @@ router.use('/users', require('./users/treinos'));
 router.use('/users', require('./users/exercicios'));
 router.use('/users', require('./users/metodos'));
 router.use('/users', require('./users/admin-invite'));
+router.use('/users', require('./users/anamnese'));
 
 
 module.exports = router;

--- a/backend/routes/users/anamnese.js
+++ b/backend/routes/users/anamnese.js
@@ -1,0 +1,45 @@
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+const admin = require('../../firebase-admin');
+const verifyToken = require('../../middleware/verifyToken');
+
+// Obter anamnese de um aluno
+router.get('/alunos/:alunoId/anamnese', verifyToken, async (req, res) => {
+    const personalId = req.user.uid;
+    const alunoId = req.params.alunoId;
+    try {
+        const doc = await admin.firestore()
+            .collection('users').doc(personalId)
+            .collection('alunos').doc(alunoId)
+            .collection('anamnese').doc('respostas').get();
+        if (!doc.exists) {
+            return res.json(null);
+        }
+        res.json(doc.data());
+    } catch (err) {
+        console.error('Erro ao obter anamnese:', err);
+        res.status(500).json({ error: 'Erro ao obter anamnese' });
+    }
+});
+
+// Criar ou atualizar anamnese do aluno
+router.post('/alunos/:alunoId/anamnese', verifyToken, async (req, res) => {
+    const personalId = req.user.uid;
+    const alunoId = req.params.alunoId;
+    const data = req.body;
+
+    try {
+        await admin.firestore()
+            .collection('users').doc(personalId)
+            .collection('alunos').doc(alunoId)
+            .collection('anamnese').doc('respostas')
+            .set(data, { merge: true });
+
+        res.status(200).json({ message: 'Anamnese salva' });
+    } catch (err) {
+        console.error('Erro ao salvar anamnese:', err);
+        res.status(500).json({ error: 'Erro ao salvar anamnese' });
+    }
+});
+
+module.exports = router;

--- a/frontend/js/anamnese.js
+++ b/frontend/js/anamnese.js
@@ -1,0 +1,110 @@
+import { fetchWithFreshToken } from './auth.js';
+
+export async function loadAnamneseSection() {
+    const content = document.getElementById('content');
+    content.innerHTML = '<h2>Carregando...</h2>';
+
+    try {
+        const res = await fetchWithFreshToken('http://localhost:3000/users/alunos');
+        const alunos = await res.json();
+        render(content, alunos);
+    } catch (err) {
+        console.error('Erro ao carregar alunos:', err);
+        content.innerHTML = '<p style="color:red;">Erro ao carregar dados</p>';
+    }
+}
+
+function render(container, alunos) {
+    const options = alunos.map(a => `<option value="${a.id}">${a.nome}</option>`).join('');
+    container.innerHTML = `
+        <h2>Anamnese</h2>
+        <input type="text" id="searchAluno" placeholder="Buscar por nome..." />
+        <select id="alunoSelect">
+            <option value="">Selecione o aluno</option>
+            ${options}
+        </select>
+        <form id="anamneseForm" class="hidden">
+            <input type="email" name="email" placeholder="Endereço de e-mail" />
+            <input type="text" name="nome" placeholder="Nome" />
+            <input type="number" name="idade" placeholder="Idade" />
+            <input type="text" name="genero" placeholder="Gênero" />
+            <input type="number" step="0.01" name="altura" placeholder="Altura" />
+            <input type="number" step="0.1" name="peso" placeholder="Peso" />
+            <textarea name="objetivos" placeholder="Objetivos"></textarea>
+            <textarea name="doencas" placeholder="Já teve ou tem alguma doença? Se sim, quais?"></textarea>
+            <textarea name="doencasFamilia" placeholder="Alguém da família tem alguma doença? Se sim, quais?"></textarea>
+            <textarea name="medicamentos" placeholder="Faz uso de medicamentos? Quais?"></textarea>
+            <textarea name="cirurgias" placeholder="Já passou por cirurgias? Quais?"></textarea>
+            <textarea name="doresLesoes" placeholder="Possui dores ou lesões?"></textarea>
+            <textarea name="limitacoes" placeholder="Alguma limitação para exercícios físicos?"></textarea>
+            <input type="text" name="fuma" placeholder="Você Fuma?" />
+            <input type="text" name="bebe" placeholder="Você Bebe? Se sim, com qual frequência?" />
+            <input type="text" name="qualidadeSono" placeholder="Qualidade do sono" />
+            <input type="number" step="0.1" name="horasSono" placeholder="Horas de sono por noite" />
+            <input type="text" name="nivelAtividade" placeholder="Nível de atividade física atual" />
+            <input type="text" name="tiposExercicio" placeholder="Tipos de exercício que pratica ou já praticou" />
+            <input type="text" name="frequenciaTreinos" placeholder="Frequência de treinos pretendida" />
+            <input type="text" name="agua" placeholder="Consome água com frequência? (litros/dia)" />
+            <input type="text" name="tempoObjetivos" placeholder="Em quanto tempo gostaria de alcançar seus objetivos?" />
+            <input type="text" name="dispostoMudanca" placeholder="Está disposto(a) a mudar hábitos alimentares e de treino?" />
+            <textarea name="comentarios" placeholder="Qualquer comentário ou observação que queira fazer"></textarea>
+            <button type="submit">Salvar</button>
+        </form>
+        <div id="mensagemAnamnese"></div>
+    `;
+
+    const searchInput = document.getElementById('searchAluno');
+    const alunoSelect = document.getElementById('alunoSelect');
+    const form = document.getElementById('anamneseForm');
+
+    searchInput.addEventListener('input', () => {
+        const term = searchInput.value.toLowerCase();
+        alunoSelect.innerHTML = '<option value="">Selecione o aluno</option>' +
+            alunos.filter(a => a.nome && a.nome.toLowerCase().includes(term))
+                  .map(a => `<option value="${a.id}">${a.nome}</option>`).join('');
+    });
+
+    alunoSelect.addEventListener('change', () => loadDadosAluno(alunoSelect.value, form));
+    form.addEventListener('submit', e => salvarAnamnese(e, alunoSelect.value));
+}
+
+async function loadDadosAluno(alunoId, form) {
+    form.reset();
+    if (!alunoId) {
+        form.classList.add('hidden');
+        return;
+    }
+    try {
+        const res = await fetchWithFreshToken(`http://localhost:3000/users/alunos/${alunoId}/anamnese`);
+        if (res.ok) {
+            const data = await res.json();
+            if (data) {
+                Object.keys(data).forEach(k => { if (form[k]) form[k].value = data[k]; });
+            }
+        }
+        form.classList.remove('hidden');
+    } catch (err) {
+        console.error('Erro ao carregar anamnese:', err);
+    }
+}
+
+async function salvarAnamnese(e, alunoId) {
+    e.preventDefault();
+    if (!alunoId) return;
+    const form = e.target;
+    const dados = {};
+    Array.from(form.elements).forEach(el => {
+        if (el.name) dados[el.name] = el.value;
+    });
+    try {
+        const res = await fetchWithFreshToken(`http://localhost:3000/users/alunos/${alunoId}/anamnese`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(dados)
+        });
+        document.getElementById('mensagemAnamnese').textContent = res.ok ? 'Anamnese salva' : 'Erro ao salvar anamnese';
+    } catch (err) {
+        console.error('Erro ao salvar anamnese:', err);
+        document.getElementById('mensagemAnamnese').textContent = 'Erro ao salvar anamnese';
+    }
+}

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -15,6 +15,9 @@ document.querySelectorAll(".sidebar li").forEach(item => {
             } else if (section === "exercicios") {
                 const { loadExerciciosSection } = await import("./exercicios.js");
                 loadExerciciosSection();
+            } else if (section === "anamnese") {
+                const { loadAnamneseSection } = await import("./anamnese.js");
+                loadAnamneseSection();
             } else if (section === "meus-treinos") {
                 const { loadMeusTreinos } = await import("./treinos.js");
                 loadMeusTreinos();


### PR DESCRIPTION
## Summary
- create backend routes to store and fetch anamnese responses
- enable anamnese route in route index
- add frontend module for anamnese with student search and questionnaire
- load the new section from dashboard menu

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68457b6a90408323bd3f945b7983b018