### PR TITLE
Add physical evaluation pages

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -18,7 +18,7 @@
             <ul class="menu">
                 <li data-section="home"><i class="fas fa-home"></i><span class="tooltip">Dashboard</span></li>
                 <li data-section="alunos"><i class="fas fa-users"></i><span class="tooltip">Alunos</span></li>
-                <li data-section="anamnese"><i class="fas fa-notes-medical"></i><span class="tooltip">Anamnese</span>
+                <li data-section="avaliacoes"><i class="fas fa-notes-medical"></i><span class="tooltip">Avaliação Física</span>
                 </li>
                 <li data-section="treinos"><i class="fas fa-dumbbell"></i><span class="tooltip">Treinos</span></li>
                 <li data-section="exercicios"><i class="fas fa-list"></i><span class="tooltip">Exercícios</span></li>

--- a/frontend/js/avaliacaoFisica.js
+++ b/frontend/js/avaliacaoFisica.js
@@ -1,0 +1,39 @@
+import { fetchWithFreshToken } from './auth.js';
+
+export function loadAvaliacaoFisicaSection(alunoId) {
+    const content = document.getElementById('content');
+    content.innerHTML = `
+        <h2>Avaliação Física</h2>
+        <form id="avaliacaoFisicaForm">
+            <input type="number" step="0.1" name="peso" placeholder="Peso (kg)" />
+            <input type="number" step="0.01" name="altura" placeholder="Altura (m)" />
+            <textarea name="dobras" placeholder="Dobras cutâneas"></textarea>
+            <textarea name="perimetria" placeholder="Perimetria"></textarea>
+            <button type="submit">Salvar</button>
+        </form>
+        <div id="msgAvalFisica"></div>
+    `;
+
+    const form = document.getElementById('avaliacaoFisicaForm');
+    form.addEventListener('submit', e => salvarAvaliacaoFisica(e, alunoId));
+}
+
+async function salvarAvaliacaoFisica(e, alunoId) {
+    e.preventDefault();
+    const dados = {};
+    const form = e.target;
+    Array.from(form.elements).forEach(el => {
+        if (el.name) dados[el.name] = el.value;
+    });
+    try {
+        const res = await fetchWithFreshToken(`http://localhost:3000/users/alunos/${alunoId}/avaliacoes`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(dados)
+        });
+        document.getElementById('msgAvalFisica').textContent = res.ok ? 'Avaliação salva' : 'Erro ao salvar avaliação';
+    } catch (err) {
+        console.error('Erro ao salvar avaliação:', err);
+        document.getElementById('msgAvalFisica').textContent = 'Erro ao salvar avaliação';
+    }
+}

--- a/frontend/js/avaliacoes.js
+++ b/frontend/js/avaliacoes.js
@@ -1,0 +1,74 @@
+import { fetchWithFreshToken } from './auth.js';
+import { loadAnamneseSection } from './anamnese.js';
+
+export async function loadAvaliacoesSection() {
+    const content = document.getElementById('content');
+    content.innerHTML = '<h2>Carregando...</h2>';
+
+    try {
+        const res = await fetchWithFreshToken('http://localhost:3000/users/alunos');
+        const alunos = await res.json();
+        render(content, alunos);
+    } catch (err) {
+        console.error('Erro ao carregar alunos:', err);
+        content.innerHTML = '<p style="color:red;">Erro ao carregar dados</p>';
+    }
+}
+
+function render(container, alunos) {
+    const options = alunos.map(a => `<option value="${a.id}">${a.nome}</option>`).join('');
+    container.innerHTML = `
+        <h2>Avaliação Física</h2>
+        <input type="text" id="searchAlunoAvaliacao" placeholder="Buscar por nome..." />
+        <select id="alunoSelectAvaliacao">
+            <option value="">Selecione o aluno</option>
+            ${options}
+        </select>
+        <div id="avaliacoesList"></div>
+        <button id="novaAvaliacao" class="hidden">Nova Avaliação</button>
+    `;
+
+    const searchInput = document.getElementById('searchAlunoAvaliacao');
+    const alunoSelect = document.getElementById('alunoSelectAvaliacao');
+    const listDiv = document.getElementById('avaliacoesList');
+    const novaBtn = document.getElementById('novaAvaliacao');
+
+    searchInput.addEventListener('input', () => {
+        const term = searchInput.value.toLowerCase();
+        alunoSelect.innerHTML = '<option value="">Selecione o aluno</option>' +
+            alunos.filter(a => a.nome && a.nome.toLowerCase().includes(term))
+                  .map(a => `<option value="${a.id}">${a.nome}</option>`).join('');
+    });
+
+    alunoSelect.addEventListener('change', () => {
+        const alunoId = alunoSelect.value;
+        if (alunoId) {
+            loadAvaliacoesAluno(alunoId, listDiv);
+            novaBtn.classList.remove('hidden');
+            novaBtn.dataset.id = alunoId;
+        } else {
+            listDiv.innerHTML = '';
+            novaBtn.classList.add('hidden');
+        }
+    });
+
+    novaBtn.addEventListener('click', () => loadAnamneseSection(novaBtn.dataset.id));
+}
+
+async function loadAvaliacoesAluno(alunoId, container) {
+    container.innerHTML = '<p>Carregando avalia\u00e7\u00f5es...</p>';
+    try {
+        const res = await fetchWithFreshToken(`http://localhost:3000/users/alunos/${alunoId}/avaliacoes`);
+        const avaliacoes = await res.json();
+        if (!avaliacoes || avaliacoes.length === 0) {
+            container.innerHTML = '<p>Nenhuma avalia\u00e7\u00e3o encontrada.</p>';
+            return;
+        }
+        container.innerHTML = '<ul>' +
+            avaliacoes.map(a => `<li>${new Date(a.data).toLocaleDateString()}</li>`).join('') +
+            '</ul>';
+    } catch (err) {
+        console.error(err);
+        container.innerHTML = '<p style="color:red;">Erro ao carregar avalia\u00e7\u00f5es</p>';
+    }
+}

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -15,9 +15,9 @@ document.querySelectorAll(".sidebar li").forEach(item => {
             } else if (section === "exercicios") {
                 const { loadExerciciosSection } = await import("./exercicios.js");
                 loadExerciciosSection();
-            } else if (section === "anamnese") {
-                const { loadAnamneseSection } = await import("./anamnese.js");
-                loadAnamneseSection();
+            } else if (section === "avaliacoes") {
+                const { loadAvaliacoesSection } = await import("./avaliacoes.js");
+                loadAvaliacoesSection();
             } else if (section === "meus-treinos") {
                 const { loadMeusTreinos } = await import("./treinos.js");
                 loadMeusTreinos();


### PR DESCRIPTION
## Summary
- rename sidebar "Anamnese" to "Avaliação Física"
- show evaluations with new `avaliacoes.js` section
- allow creating evaluation with prefilled anamnese
- implement next step for physical evaluation form

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684741b79124832387694e798b241212