### PR TITLE
Add dashboard layout for avaliacao page

### DIFF
--- a/frontend/avaliacao.html
+++ b/frontend/avaliacao.html
@@ -3,18 +3,44 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Nova Avaliação | PersonalHub</title>
+    <title>Avaliação | PersonalHub</title>
     <link rel="stylesheet" href="./css/styles.css" />
     <link rel="stylesheet" href="./css/dashboard.css" />
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet" />
     <script src="https://kit.fontawesome.com/2c9298b4bd.js" crossorigin="anonymous"></script>
 </head>
 <body>
-    <header class="header">
-        <h1><span style="color:#f58725;">Personal</span>Hub</h1>
-        <div id="alunoInfo"></div>
-    </header>
-    <main id="avaliacaoOpcoes" class="opcoes-avaliacao"></main>
-    <script type="module" src="./js/avaliacao.js"></script>
+    <div class="dashboard">
+        <aside class="sidebar">
+            <div class="logo">🏋️</div>
+            <ul class="menu">
+                <li data-section="home"><i class="fas fa-home"></i><span class="tooltip">Dashboard</span></li>
+                <li data-section="alunos"><i class="fas fa-users"></i><span class="tooltip">Alunos</span></li>
+                <li data-section="avaliacoes"><i class="fas fa-notes-medical"></i><span class="tooltip">Avaliação Física</span></li>
+                <li data-section="treinos"><i class="fas fa-dumbbell"></i><span class="tooltip">Treinos</span></li>
+                <li data-section="exercicios"><i class="fas fa-list"></i><span class="tooltip">Exercícios</span></li>
+                <li data-section="agenda"><i class="fas fa-calendar-alt"></i><span class="tooltip">Agenda</span></li>
+                <li data-section="relatorios"><i class="fas fa-chart-line"></i><span class="tooltip">Relatórios</span></li>
+                <li id="logoutBtn"><i class="fas fa-sign-out-alt"></i><span class="tooltip">Sair</span></li>
+            </ul>
+        </aside>
+
+        <div class="main">
+            <header class="header">
+                <h1><span style="color:#f58725;">Personal</span>Hub</h1>
+                <span id="userGreeting">Olá, Personal</span>
+            </header>
+
+            <main id="content">
+                <div id="alunoHeader"></div>
+                <div id="avaliacoesFeitas"></div>
+                <button id="novaAvaliacaoBtn">Nova Avaliação</button>
+                <div id="avaliacaoOpcoes" class="opcoes-avaliacao hidden"></div>
+            </main>
+        </div>
+    </div>
+
+    <script type="module" src="./js/dashboard.js"></script>
+    <script type="module" src="./js/avaliacaoPagina.js"></script>
 </body>
 </html>

--- a/frontend/js/avaliacao.js
+++ b/frontend/js/avaliacao.js
@@ -1,24 +1,27 @@
 import { fetchWithFreshToken } from './auth.js';
 
-function getAlunoId() {
+export function getAlunoId() {
     const params = new URLSearchParams(window.location.search);
     return params.get('id');
 }
 
-async function loadAlunoInfo(id) {
+export async function loadAlunoInfo(id, targetId = 'alunoInfo') {
     if (!id) return;
     try {
         const res = await fetchWithFreshToken(`http://localhost:3000/users/alunos/${id}`);
         if (res.ok) {
             const aluno = await res.json();
-            document.getElementById('alunoInfo').textContent = `${aluno.nome || ''} - ${aluno.email || ''}`;
+            const target = document.getElementById(targetId);
+            if (target) {
+                target.textContent = `${aluno.nome || ''} - ${aluno.email || ''}`;
+            }
         }
     } catch (err) {
         console.error('Erro ao carregar aluno', err);
     }
 }
 
-function renderOpcoes(id) {
+export function renderOpcoes(id, containerId = 'avaliacaoOpcoes') {
     const opcoes = [
         { titulo: 'Anamnese', icone: 'fa-notes-medical', link: `anamnese_form.html?id=${id}` },
         { titulo: 'Composição Corporal', icone: 'fa-weight', link: `composicao.html?id=${id}` },
@@ -28,17 +31,21 @@ function renderOpcoes(id) {
         { titulo: 'Força', icone: 'fa-dumbbell', link: `forca.html?id=${id}` }
     ];
 
-    const container = document.getElementById('avaliacaoOpcoes');
-    container.innerHTML = opcoes.map(o => `
-        <a class="box-opcao" href="${o.link}">
-            <i class="fas ${o.icone}"></i>
-            <span>${o.titulo}</span>
-        </a>
-    `).join('');
+    const container = document.getElementById(containerId);
+    if (container) {
+        container.innerHTML = opcoes.map(o => `
+            <a class="box-opcao" href="${o.link}">
+                <i class="fas ${o.icone}"></i>
+                <span>${o.titulo}</span>
+            </a>
+        `).join('');
+    }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
     const id = getAlunoId();
-    loadAlunoInfo(id);
-    renderOpcoes(id);
+    if (document.getElementById('avaliacaoOpcoes')) {
+        loadAlunoInfo(id);
+        renderOpcoes(id);
+    }
 });

--- a/frontend/js/avaliacaoPagina.js
+++ b/frontend/js/avaliacaoPagina.js
@@ -1,0 +1,42 @@
+import { getAlunoId, loadAlunoInfo, renderOpcoes } from './avaliacao.js';
+import { fetchWithFreshToken } from './auth.js';
+
+async function carregarAvaliacoes(id) {
+    const container = document.getElementById('avaliacoesFeitas');
+    if (!container) return;
+    container.innerHTML = '<p>Carregando avaliações...</p>';
+    try {
+        const res = await fetchWithFreshToken(`http://localhost:3000/users/alunos/${id}/avaliacoes`);
+        const avaliacoes = await res.json();
+        if (!avaliacoes || avaliacoes.length === 0) {
+            container.innerHTML = '<p>Nenhuma avaliação encontrada.</p>';
+            return;
+        }
+        container.innerHTML = '<ul>' +
+            avaliacoes.map(a => `<li>${new Date(a.data).toLocaleDateString()}</li>`).join('') +
+            '</ul>';
+    } catch (err) {
+        console.error(err);
+        container.innerHTML = '<p style="color:red;">Erro ao carregar avaliações</p>';
+    }
+}
+
+function setupNovaAvaliacao(id) {
+    const btn = document.getElementById('novaAvaliacaoBtn');
+    if (!btn) return;
+    btn.addEventListener('click', () => {
+        btn.classList.add('hidden');
+        const lista = document.getElementById('avaliacoesFeitas');
+        if (lista) lista.classList.add('hidden');
+        renderOpcoes(id, 'avaliacaoOpcoes');
+        const opcoes = document.getElementById('avaliacaoOpcoes');
+        if (opcoes) opcoes.classList.remove('hidden');
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const id = getAlunoId();
+    loadAlunoInfo(id, 'alunoHeader');
+    carregarAvaliacoes(id);
+    setupNovaAvaliacao(id);
+});


### PR DESCRIPTION
## Summary
- keep dashboard sidebar and header on `avaliacao.html`
- export helper functions from `avaliacao.js`
- add new `avaliacaoPagina.js` to list previous evaluations and show options

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684773f4955483238d8f4d21f2a2c002