### PR TITLE
Add nova avaliacao menu page

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -146,3 +146,61 @@ select:focus {
     outline: none;
     background-color: #2e2e2e;
 }
+/* ===== Nova Avaliacao ===== */
+.page-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    background-color: #1e1e1e;
+    padding: 10px 20px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.5);
+    z-index: 100;
+}
+
+.page-header h2 {
+    margin: 0;
+    font-size: 20px;
+}
+
+.back-btn {
+    background: none;
+    border: none;
+    color: #f58725;
+    font-size: 20px;
+    cursor: pointer;
+}
+
+.avaliacao-main {
+    max-width: 1000px;
+    margin: 80px auto 0;
+    padding: 20px;
+}
+
+.aluno-info {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    margin-bottom: 20px;
+    background-color: #1e1e1e;
+    padding: 20px;
+    border-radius: 6px;
+}
+
+.foto-aluno {
+    width: 80px;
+    height: 80px;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
+.dados-aluno h3 {
+    margin: 0 0 5px;
+}
+
+.dados-aluno input[type="date"] {
+    width: auto;
+}

--- a/frontend/js/avaliacaoPagina.js
+++ b/frontend/js/avaliacaoPagina.js
@@ -25,12 +25,9 @@ function setupNovaAvaliacao(id) {
     const btn = document.getElementById('novaAvaliacaoBtn');
     if (!btn) return;
     btn.addEventListener('click', () => {
-        btn.classList.add('hidden');
-        const lista = document.getElementById('avaliacoesFeitas');
-        if (lista) lista.classList.add('hidden');
-        renderOpcoes(id, 'avaliacaoOpcoes');
-        const opcoes = document.getElementById('avaliacaoOpcoes');
-        if (opcoes) opcoes.classList.remove('hidden');
+        if (id) {
+            window.location.href = `nova_avaliacao.html?id=${id}`;
+        }
     });
 }
 

--- a/frontend/js/novaAvaliacao.js
+++ b/frontend/js/novaAvaliacao.js
@@ -1,0 +1,31 @@
+import { getAlunoId, renderOpcoes } from './avaliacao.js';
+import { fetchWithFreshToken } from './auth.js';
+
+async function carregarCabecalho(id) {
+    if (!id) return;
+    try {
+        const res = await fetchWithFreshToken(`http://localhost:3000/users/alunos/${id}`);
+        if (res.ok) {
+            const aluno = await res.json();
+            const nomeEl = document.getElementById('nomeAluno');
+            const idadeEl = document.getElementById('idadeAluno');
+            const sexoEl = document.getElementById('sexoAluno');
+            const fotoEl = document.getElementById('fotoAluno');
+            if (nomeEl) nomeEl.textContent = aluno.nome || '';
+            if (idadeEl && aluno.idade) idadeEl.textContent = `${aluno.idade} anos`;
+            if (sexoEl && aluno.sexo) sexoEl.textContent = aluno.sexo;
+            if (fotoEl && aluno.fotoUrl) fotoEl.src = aluno.fotoUrl;
+        }
+    } catch (err) {
+        console.error('Erro ao carregar aluno', err);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const id = getAlunoId();
+    carregarCabecalho(id);
+    renderOpcoes(id, 'avaliacaoOpcoes');
+
+    const back = document.getElementById('backBtn');
+    if (back) back.addEventListener('click', () => window.history.back());
+});

--- a/frontend/nova_avaliacao.html
+++ b/frontend/nova_avaliacao.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nova Avaliação</title>
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/dashboard.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet" />
+    <script src="https://kit.fontawesome.com/2c9298b4bd.js" crossorigin="anonymous"></script>
+</head>
+<body>
+    <header class="page-header">
+        <button id="backBtn" class="back-btn">⬅</button>
+        <h2>Nova Avaliação</h2>
+    </header>
+    <main class="avaliacao-main">
+        <section id="alunoInfo" class="aluno-info">
+            <img id="fotoAluno" class="foto-aluno" src="" alt="Foto do aluno" />
+            <div class="dados-aluno">
+                <h3 id="nomeAluno"></h3>
+                <p id="idadeAluno"></p>
+                <p id="sexoAluno"></p>
+                <label>
+                    Data da próxima avaliação
+                    <input type="date" id="proximaAvaliacao" />
+                </label>
+            </div>
+        </section>
+        <section id="avaliacaoOpcoes" class="opcoes-avaliacao"></section>
+    </main>
+    <script type="module" src="./js/novaAvaliacao.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a dedicated page for starting a new evaluation
- load student info and show evaluation modules on that page
- link the existing `Nova Avaliação` button to this new page
- style page header and student info section

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684790cba6d88323852ab2cf59e029b1