### PR TITLE
Fix new evaluation navigation

### DIFF
--- a/frontend/js/avaliacoes.js
+++ b/frontend/js/avaliacoes.js
@@ -106,7 +106,7 @@ function render(container, alunos) {
 
     novaBtn.addEventListener('click', () => {
         if (novaBtn.dataset.id) {
-            window.location.href = `avaliacao.html?id=${novaBtn.dataset.id}`;
+            window.location.href = `nova_avaliacao.html?id=${novaBtn.dataset.id}`;
         }
     });
 }


### PR DESCRIPTION
## Summary
- skip the intermediary `avaliacao.html` when creating a new evaluation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c8b3d52248323813920d2003c74f2