### PR TITLE
Add Google Sheets import for anamnese

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,8 @@
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
-        "firebase-admin": "^13.4.0"
+        "firebase-admin": "^13.4.0",
+        "googleapis": "^105.0.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.10"
@@ -2635,6 +2636,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "105.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-105.0.0.tgz",
+      "integrity": "",
+      "dependencies": {
+        "google-auth-library": "^9.3.0"
       }
     },
     "node_modules/yargs-parser": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "firebase-admin": "^13.4.0"
+    "firebase-admin": "^13.4.0",
+    "googleapis": "^105.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/backend/routes/users/anamnese.js
+++ b/backend/routes/users/anamnese.js
@@ -42,4 +42,41 @@ router.post('/alunos/:alunoId/anamnese', verifyToken, async (req, res) => {
     }
 });
 
+// Importar dados da planilha do Google Sheets pelo email do aluno
+router.get('/alunos/:alunoId/anamnese/sheet', verifyToken, async (req, res) => {
+    const email = req.query.email;
+    if (!email) return res.status(400).json({ error: 'Email requerido' });
+
+    try {
+        const { google } = require('googleapis');
+        const auth = new google.auth.GoogleAuth({
+            scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly']
+        });
+        const client = await auth.getClient();
+        const sheets = google.sheets({ version: 'v4', auth: client });
+
+        const spreadsheetId = process.env.GOOGLE_SHEETS_ID;
+        const range = process.env.GOOGLE_SHEETS_RANGE || 'Sheet1!A:Z';
+        const sheetRes = await sheets.spreadsheets.values.get({
+            spreadsheetId,
+            range
+        });
+        const rows = sheetRes.data.values;
+        if (!rows || rows.length === 0) return res.json(null);
+        const headers = rows[0].map(h => h.trim());
+        const emailIdx = headers.findIndex(h => h.toLowerCase() === 'email');
+        if (emailIdx === -1) return res.json(null);
+        const row = rows.find((r, i) => i > 0 && r[emailIdx] && r[emailIdx].toLowerCase() === email.toLowerCase());
+        if (!row) return res.json(null);
+        const data = {};
+        headers.forEach((h, idx) => {
+            if (row[idx] !== undefined) data[h] = row[idx];
+        });
+        res.json(data);
+    } catch (err) {
+        console.error('Erro ao importar planilha:', err);
+        res.status(500).json({ error: 'Erro ao importar planilha' });
+    }
+});
+
 module.exports = router;

--- a/frontend/anamnese_form.html
+++ b/frontend/anamnese_form.html
@@ -36,6 +36,7 @@
             <textarea name="comentarios" placeholder="Qualquer comentário ou observação que queira fazer"></textarea>
             <div class="form-actions">
                 <button type="button" id="voltar">Voltar</button>
+                <button type="button" id="importarPlanilha">Importar do Google Sheets</button>
                 <button type="submit">Salvar</button>
             </div>
         </form>
@@ -51,6 +52,30 @@
 
         document.getElementById('voltar').addEventListener('click', () => {
             window.location.href = `avaliacao.html?id=${id}`;
+        });
+
+        document.getElementById('importarPlanilha').addEventListener('click', async () => {
+            if (!form.email || !form.email.value) {
+                msg.textContent = 'Preencha o email para importar';
+                return;
+            }
+            try {
+                const res = await fetchWithFreshToken(`http://localhost:3000/users/alunos/${id}/anamnese/sheet?email=${encodeURIComponent(form.email.value)}`);
+                if (res.ok) {
+                    const data = await res.json();
+                    if (data) {
+                        Object.keys(data).forEach(k => { if (form[k]) form[k].value = data[k]; });
+                        msg.textContent = 'Dados importados do Google Sheets';
+                    } else {
+                        msg.textContent = 'Nenhum dado encontrado no Google Sheets';
+                    }
+                } else {
+                    msg.textContent = 'Erro ao importar dados';
+                }
+            } catch (err) {
+                console.error('Erro ao importar planilha:', err);
+                msg.textContent = 'Erro ao importar planilha';
+            }
         });
 
         form.addEventListener('submit', async e => {


### PR DESCRIPTION
## Summary
- update backend dependencies to include `googleapis`
- enable importing anamnese data from Google Sheets
- add button in anamnese form to fetch spreadsheet data using student's email

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ca7a65ea88323a1666d4f9300b983