### PR TITLE
Add finalization buttons for evaluations

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -204,3 +204,10 @@ select:focus {
 .dados-aluno input[type="date"] {
     width: auto;
 }
+
+.avaliacao-actions {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    margin-top: 20px;
+}

--- a/frontend/js/avaliacoes.js
+++ b/frontend/js/avaliacoes.js
@@ -85,23 +85,30 @@ function render(container, alunos) {
         novaBtn.dataset.id = alunoId;
         novaBtn.classList.remove('hidden');
         listDiv.innerHTML = '<p>Carregando avaliações...</p>';
+        let avaliacoes = [];
         try {
             const res = await fetchWithFreshToken(`http://localhost:3000/users/alunos/${alunoId}/avaliacoes`);
-            const avaliacoes = await res.json();
-            if (!avaliacoes || avaliacoes.length === 0) {
-                listDiv.innerHTML = '<p class="sem-avaliacoes">Este aluno ainda não possui avaliações cadastradas.</p>';
-                return;
+            if (res.ok) {
+                avaliacoes = await res.json();
             }
-            listDiv.innerHTML = avaliacoes.map(a => `
-                <div class="avaliacao-card">
-                    <span>${new Date(a.data).toLocaleDateString()}</span>
-                    <button class="btn-visualizar" data-id="${a.id || ''}">Visualizar</button>
-                </div>
-            `).join('');
         } catch (err) {
             console.error(err);
-            listDiv.innerHTML = '<p style="color:red;">Erro ao carregar avaliações</p>';
         }
+
+        const locais = JSON.parse(localStorage.getItem(`avaliacoes_${alunoId}`) || '[]');
+        avaliacoes = avaliacoes.concat(locais);
+
+        if (!avaliacoes || avaliacoes.length === 0) {
+            listDiv.innerHTML = '<p class="sem-avaliacoes">Este aluno ainda não possui avaliações cadastradas.</p>';
+            return;
+        }
+
+        listDiv.innerHTML = avaliacoes.map(a => `
+            <div class="avaliacao-card">
+                <span>${new Date(a.data).toLocaleDateString()}</span>
+                <button class="btn-visualizar" data-id="${a.id || ''}">Visualizar</button>
+            </div>
+        `).join('');
     }
 
     novaBtn.addEventListener('click', () => {

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -53,6 +53,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
             greet.textContent = `Olá, ${roleText}`;
         }
+        const params = new URLSearchParams(window.location.search);
+        const sec = params.get('section');
+        if (sec) {
+            const li = document.querySelector(`.sidebar li[data-section="${sec}"]`);
+            if (li) li.click();
+        }
     } catch (err) {
         console.error('Erro ao obter role:', err);
     }

--- a/frontend/js/novaAvaliacao.js
+++ b/frontend/js/novaAvaliacao.js
@@ -26,6 +26,28 @@ document.addEventListener('DOMContentLoaded', () => {
     carregarCabecalho(id);
     renderOpcoes(id, 'avaliacaoOpcoes');
 
-    const back = document.getElementById('backBtn');
-    if (back) back.addEventListener('click', () => window.history.back());
+    const finalizar = document.getElementById('finalizarAvaliacao');
+    const cancelar = document.getElementById('cancelarAvaliacao');
+
+    if (cancelar) {
+        cancelar.addEventListener('click', () => {
+            window.location.href = 'dashboard.html?section=avaliacoes';
+        });
+    }
+
+    if (finalizar) {
+        finalizar.addEventListener('click', () => {
+            const proxima = document.getElementById('proximaAvaliacao');
+            const avaliacao = {
+                id: Date.now(),
+                data: new Date().toISOString(),
+                proxima: proxima ? proxima.value : ''
+            };
+            const chave = `avaliacoes_${id}`;
+            const lista = JSON.parse(localStorage.getItem(chave) || '[]');
+            lista.push(avaliacao);
+            localStorage.setItem(chave, JSON.stringify(lista));
+            window.location.href = 'dashboard.html?section=avaliacoes';
+        });
+    }
 });

--- a/frontend/nova_avaliacao.html
+++ b/frontend/nova_avaliacao.html
@@ -11,7 +11,6 @@
 </head>
 <body>
     <header class="page-header">
-        <button id="backBtn" class="back-btn">⬅</button>
         <h2>Nova Avaliação</h2>
     </header>
     <main class="avaliacao-main">
@@ -28,6 +27,10 @@
             </div>
         </section>
         <section id="avaliacaoOpcoes" class="opcoes-avaliacao"></section>
+        <div class="avaliacao-actions">
+            <button id="cancelarAvaliacao">Cancelar Avaliação</button>
+            <button id="finalizarAvaliacao">Finalizar Avaliação</button>
+        </div>
     </main>
     <script type="module" src="./js/novaAvaliacao.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- show cancel/finalize buttons in new evaluation page
- persist finished evaluations in localStorage
- load saved evaluations back in Avaliações page
- allow dashboard to load a section from URL query

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684db8b188a88323a4b258225fb0f6b4