### PR TITLE
Enable viewing and saving of assessment data

### DIFF
--- a/frontend/anamnese_form.html
+++ b/frontend/anamnese_form.html
@@ -148,6 +148,7 @@
             e.preventDefault();
             const dados = {};
             Array.from(form.elements).forEach(el => { if (el.name) dados[el.name] = el.value; });
+            const avalId = localStorage.getItem(`currentAvalId_${id}`);
             try {
                 const res = await fetchWithFreshToken(`http://localhost:3000/users/alunos/${id}/anamnese`, {
                     method: 'POST',
@@ -155,6 +156,10 @@
                     body: JSON.stringify(dados)
                 });
                 msg.textContent = res.ok ? 'Anamnese salva' : 'Erro ao salvar anamnese';
+                if (res.ok) {
+                    if (avalId) localStorage.setItem(`avaliacao_${id}_${avalId}_anamnese`, JSON.stringify(dados));
+                    window.location.href = `nova_avaliacao.html?id=${id}`;
+                }
             } catch (err) {
                 console.error('Erro ao salvar anamnese:', err);
                 msg.textContent = 'Erro ao salvar anamnese';

--- a/frontend/composicao.html
+++ b/frontend/composicao.html
@@ -55,6 +55,10 @@
         });
         document.getElementById('compForm').addEventListener('submit', e => {
             e.preventDefault();
+            const avalId = localStorage.getItem(`currentAvalId_${id}`);
+            const dados = {};
+            Array.from(e.target.elements).forEach(el => { if (el.name) dados[el.name] = el.value; });
+            if (avalId) localStorage.setItem(`avaliacao_${id}_${avalId}_composicao`, JSON.stringify(dados));
             window.location.href = `nova_avaliacao.html?id=${id}`;
         });
     </script>

--- a/frontend/flexibilidade.html
+++ b/frontend/flexibilidade.html
@@ -55,7 +55,12 @@
         });
         document.getElementById('flexForm').addEventListener('submit', e => {
             e.preventDefault();
-            document.getElementById('msgFlex').textContent = 'Dados salvos (exemplo)';
+            const avalId = localStorage.getItem(`currentAvalId_${id}`);
+            const dados = {};
+            Array.from(e.target.elements).forEach(el => { if (el.name) dados[el.name] = el.value; });
+            if (avalId) localStorage.setItem(`avaliacao_${id}_${avalId}_flexibilidade`, JSON.stringify(dados));
+            document.getElementById('msgFlex').textContent = 'Dados salvos';
+            window.location.href = `nova_avaliacao.html?id=${id}`;
         });
     </script>
 </body>

--- a/frontend/js/avaliacoes.js
+++ b/frontend/js/avaliacoes.js
@@ -109,6 +109,13 @@ function render(container, alunos) {
                 <button class="btn-visualizar" data-id="${a.id || ''}">Visualizar</button>
             </div>
         `).join('');
+
+        listDiv.querySelectorAll('.btn-visualizar').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const avalId = btn.dataset.id;
+                window.location.href = `visualizar_avaliacao.html?alunoId=${alunoId}&avaliacaoId=${avalId}`;
+            });
+        });
     }
 
     novaBtn.addEventListener('click', () => {

--- a/frontend/js/novaAvaliacao.js
+++ b/frontend/js/novaAvaliacao.js
@@ -26,27 +26,42 @@ document.addEventListener('DOMContentLoaded', () => {
     carregarCabecalho(id);
     renderOpcoes(id, 'avaliacaoOpcoes');
 
+    // cria/recupera id da avaliacao em andamento
+    let avalId = localStorage.getItem(`currentAvalId_${id}`);
+    if (!avalId) {
+        avalId = Date.now().toString();
+        localStorage.setItem(`currentAvalId_${id}`, avalId);
+    }
+
     const finalizar = document.getElementById('finalizarAvaliacao');
     const cancelar = document.getElementById('cancelarAvaliacao');
 
     if (cancelar) {
         cancelar.addEventListener('click', () => {
+            localStorage.removeItem(`currentAvalId_${id}`);
             window.location.href = 'dashboard.html?section=avaliacoes';
         });
     }
 
     if (finalizar) {
         finalizar.addEventListener('click', () => {
+            const avalId = localStorage.getItem(`currentAvalId_${id}`);
             const proxima = document.getElementById('proximaAvaliacao');
             const avaliacao = {
-                id: Date.now(),
+                id: avalId,
                 data: new Date().toISOString(),
                 proxima: proxima ? proxima.value : ''
             };
             const chave = `avaliacoes_${id}`;
             const lista = JSON.parse(localStorage.getItem(chave) || '[]');
-            lista.push(avaliacao);
+            const idx = lista.findIndex(a => a.id === avalId);
+            if (idx >= 0) {
+                lista[idx] = avaliacao;
+            } else {
+                lista.push(avaliacao);
+            }
             localStorage.setItem(chave, JSON.stringify(lista));
+            localStorage.removeItem(`currentAvalId_${id}`);
             window.location.href = 'dashboard.html?section=avaliacoes';
         });
     }

--- a/frontend/perimetria.html
+++ b/frontend/perimetria.html
@@ -42,8 +42,12 @@
         });
         document.getElementById('perimetriaForm').addEventListener('submit', e => {
             e.preventDefault();
-            // aqui poderia ser enviada ao backend
-            document.getElementById('msgPerimetria').textContent = 'Dados salvos (exemplo)';
+            const avalId = localStorage.getItem(`currentAvalId_${id}`);
+            const dados = {};
+            Array.from(e.target.elements).forEach(el => { if (el.name) dados[el.name] = el.value; });
+            if (avalId) localStorage.setItem(`avaliacao_${id}_${avalId}_perimetria`, JSON.stringify(dados));
+            document.getElementById('msgPerimetria').textContent = 'Dados salvos';
+            window.location.href = `nova_avaliacao.html?id=${id}`;
         });
     </script>
 </body>

--- a/frontend/postural.html
+++ b/frontend/postural.html
@@ -499,7 +499,12 @@
         });
         document.getElementById('posturalForm').addEventListener('submit', e => {
             e.preventDefault();
-            document.getElementById('msgPostural').textContent = 'Dados salvos (exemplo)';
+            const avalId = localStorage.getItem(`currentAvalId_${id}`);
+            const dados = {};
+            Array.from(e.target.elements).forEach(el => { if (el.name) dados[el.name] = el.value; });
+            if (avalId) localStorage.setItem(`avaliacao_${id}_${avalId}_postural`, JSON.stringify(dados));
+            document.getElementById('msgPostural').textContent = 'Dados salvos';
+            window.location.href = `nova_avaliacao.html?id=${id}`;
         });
     </script>
 </body>

--- a/frontend/visualizar_avaliacao.html
+++ b/frontend/visualizar_avaliacao.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Visualizar Avaliação</title>
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/dashboard.css" />
+</head>
+<body>
+    <div class="avaliacao-container">
+        <h2>Avaliação</h2>
+        <div id="dadosAvaliacao"></div>
+        <div class="form-actions">
+            <button type="button" id="voltar">Voltar</button>
+        </div>
+    </div>
+    <script type="module">
+        document.addEventListener('DOMContentLoaded', () => {
+            const params = new URLSearchParams(window.location.search);
+            const alunoId = params.get('alunoId');
+            const avalId = params.get('avaliacaoId');
+            const container = document.getElementById('dadosAvaliacao');
+            if (!alunoId || !avalId) {
+                container.textContent = 'Avaliação não encontrada';
+                return;
+            }
+            const lista = JSON.parse(localStorage.getItem(`avaliacoes_${alunoId}`) || '[]');
+            const avaliacao = lista.find(a => String(a.id) === avalId);
+            if (!avaliacao) {
+                container.textContent = 'Avaliação não encontrada';
+                return;
+            }
+            const partes = ['anamnese','composicao','perimetria','flexibilidade','postural'];
+            const dadosPartes = partes.map(p => {
+                const dados = localStorage.getItem(`avaliacao_${alunoId}_${avalId}_${p}`);
+                if (dados) return `<h3>${p}</h3><pre>${JSON.stringify(JSON.parse(dados), null, 2)}</pre>`;
+                return '';
+            }).join('');
+            container.innerHTML = `<p>Data: ${new Date(avaliacao.data).toLocaleDateString()}</p>` +
+                `<p>Próxima Avaliação: ${avaliacao.proxima || '-'}</p>` + dadosPartes;
+            document.getElementById('voltar').addEventListener('click', () => window.history.back());
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- persist evaluation data with a temporary `currentAvalId`
- redirect to new evaluation page after saving form parts
- store data locally for composition, flexibility, perimetry and postural screens
- save anamnese data locally after sending to backend
- allow viewing of saved evaluations via new page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dbb028f888323b4e82d4ab985b5c7