### PR TITLE
Enable editing and deletion of saved evaluations

### DIFF
--- a/frontend/anamnese_form.html
+++ b/frontend/anamnese_form.html
@@ -182,6 +182,14 @@
                         Object.keys(data).forEach(k => { if (form[k]) form[k].value = data[k]; });
                     }
                 }
+                const avalId = localStorage.getItem(`currentAvalId_${id}`);
+                if (avalId) {
+                    const local = localStorage.getItem(`avaliacao_${id}_${avalId}_anamnese`);
+                    if (local) {
+                        const obj = JSON.parse(local);
+                        Object.keys(obj).forEach(k => { if (form[k]) form[k].value = obj[k]; });
+                    }
+                }
             } catch (err) {
                 console.error('Erro ao carregar anamnese:', err);
             }

--- a/frontend/composicao.html
+++ b/frontend/composicao.html
@@ -50,6 +50,19 @@
         protocoloSelect.addEventListener('change', atualizarDobras);
         atualizarDobras();
 
+        const avalId = localStorage.getItem(`currentAvalId_${id}`);
+        if (avalId) {
+            const local = localStorage.getItem(`avaliacao_${id}_${avalId}_composicao`);
+            if (local) {
+                const obj = JSON.parse(local);
+                Object.keys(obj).forEach(k => {
+                    const el = document.querySelector(`[name="${k}"]`);
+                    if (el) el.value = obj[k];
+                });
+                atualizarDobras();
+            }
+        }
+
         document.getElementById('voltar').addEventListener('click', () => {
             window.location.href = `nova_avaliacao.html?id=${id}`;
         });

--- a/frontend/css/dashboard.css
+++ b/frontend/css/dashboard.css
@@ -384,6 +384,10 @@ body {
     margin-bottom: 10px;
 }
 
+.avaliacao-part {
+    margin-top: 20px;
+}
+
 .sem-avaliacoes {
     text-align: center;
     margin: 20px 0;

--- a/frontend/flexibilidade.html
+++ b/frontend/flexibilidade.html
@@ -53,7 +53,18 @@
         document.getElementById('voltar').addEventListener('click', () => {
             window.location.href = `nova_avaliacao.html?id=${id}`;
         });
-        document.getElementById('flexForm').addEventListener('submit', e => {
+        const form = document.getElementById('flexForm');
+
+        const avalId = localStorage.getItem(`currentAvalId_${id}`);
+        if (avalId) {
+            const local = localStorage.getItem(`avaliacao_${id}_${avalId}_flexibilidade`);
+            if (local) {
+                const obj = JSON.parse(local);
+                Object.keys(obj).forEach(k => { const el = form.querySelector(`[name="${k}"]`); if (el) el.value = obj[k]; });
+            }
+        }
+
+        form.addEventListener('submit', e => {
             e.preventDefault();
             const avalId = localStorage.getItem(`currentAvalId_${id}`);
             const dados = {};

--- a/frontend/js/avaliacoes.js
+++ b/frontend/js/avaliacoes.js
@@ -106,7 +106,11 @@ function render(container, alunos) {
         listDiv.innerHTML = avaliacoes.map(a => `
             <div class="avaliacao-card">
                 <span>${new Date(a.data).toLocaleDateString()}</span>
-                <button class="btn-visualizar" data-id="${a.id || ''}">Visualizar</button>
+                <div>
+                    <button class="btn-visualizar" data-id="${a.id || ''}">Visualizar</button>
+                    <button class="btn-editar" data-id="${a.id || ''}">Editar</button>
+                    <button class="btn-excluir" data-id="${a.id || ''}">Excluir</button>
+                </div>
             </div>
         `).join('');
 
@@ -114,6 +118,26 @@ function render(container, alunos) {
             btn.addEventListener('click', () => {
                 const avalId = btn.dataset.id;
                 window.location.href = `visualizar_avaliacao.html?alunoId=${alunoId}&avaliacaoId=${avalId}`;
+            });
+        });
+        listDiv.querySelectorAll('.btn-editar').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const avalId = btn.dataset.id;
+                localStorage.setItem(`currentAvalId_${alunoId}`, avalId);
+                window.location.href = `nova_avaliacao.html?id=${alunoId}`;
+            });
+        });
+        listDiv.querySelectorAll('.btn-excluir').forEach(btn => {
+            btn.addEventListener('click', () => {
+                if (confirm('Deseja excluir esta avaliação?')) {
+                    const avalId = btn.dataset.id;
+                    const chave = `avaliacoes_${alunoId}`;
+                    const lista = JSON.parse(localStorage.getItem(chave) || '[]').filter(a => String(a.id) !== avalId);
+                    localStorage.setItem(chave, JSON.stringify(lista));
+                    const partes = ['anamnese','composicao','perimetria','flexibilidade','postural'];
+                    partes.forEach(p => localStorage.removeItem(`avaliacao_${alunoId}_${avalId}_${p}`));
+                    mostrarAvaliacoes(alunoId, nome);
+                }
             });
         });
     }

--- a/frontend/js/novaAvaliacao.js
+++ b/frontend/js/novaAvaliacao.js
@@ -31,6 +31,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!avalId) {
         avalId = Date.now().toString();
         localStorage.setItem(`currentAvalId_${id}`, avalId);
+    } else {
+        const lista = JSON.parse(localStorage.getItem(`avaliacoes_${id}`) || '[]');
+        const existente = lista.find(a => a.id === avalId);
+        if (existente && document.getElementById('proximaAvaliacao')) {
+            document.getElementById('proximaAvaliacao').value = existente.proxima || '';
+        }
     }
 
     const finalizar = document.getElementById('finalizarAvaliacao');

--- a/frontend/perimetria.html
+++ b/frontend/perimetria.html
@@ -37,10 +37,21 @@
     <script type="module">
         const params = new URLSearchParams(window.location.search);
         const id = params.get('id');
+        const form = document.getElementById('perimetriaForm');
         document.getElementById('voltar').addEventListener('click', () => {
             window.location.href = `nova_avaliacao.html?id=${id}`;
         });
-        document.getElementById('perimetriaForm').addEventListener('submit', e => {
+
+        const avalId = localStorage.getItem(`currentAvalId_${id}`);
+        if (avalId) {
+            const local = localStorage.getItem(`avaliacao_${id}_${avalId}_perimetria`);
+            if (local) {
+                const obj = JSON.parse(local);
+                Object.keys(obj).forEach(k => { const el = form.querySelector(`[name="${k}"]`); if (el) el.value = obj[k]; });
+            }
+        }
+
+        form.addEventListener('submit', e => {
             e.preventDefault();
             const avalId = localStorage.getItem(`currentAvalId_${id}`);
             const dados = {};

--- a/frontend/postural.html
+++ b/frontend/postural.html
@@ -494,10 +494,21 @@
     <script type="module">
         const params = new URLSearchParams(window.location.search);
         const id = params.get('id');
+        const form = document.getElementById('posturalForm');
         document.getElementById('voltar').addEventListener('click', () => {
             window.location.href = `nova_avaliacao.html?id=${id}`;
         });
-        document.getElementById('posturalForm').addEventListener('submit', e => {
+
+        const avalId = localStorage.getItem(`currentAvalId_${id}`);
+        if (avalId) {
+            const local = localStorage.getItem(`avaliacao_${id}_${avalId}_postural`);
+            if (local) {
+                const obj = JSON.parse(local);
+                Object.keys(obj).forEach(k => { const el = form.querySelector(`[name="${k}"]`); if (el) el.value = obj[k]; });
+            }
+        }
+
+        form.addEventListener('submit', e => {
             e.preventDefault();
             const avalId = localStorage.getItem(`currentAvalId_${id}`);
             const dados = {};

--- a/frontend/visualizar_avaliacao.html
+++ b/frontend/visualizar_avaliacao.html
@@ -12,6 +12,8 @@
         <h2>Avaliação</h2>
         <div id="dadosAvaliacao"></div>
         <div class="form-actions">
+            <button type="button" id="editar">Editar</button>
+            <button type="button" id="excluir">Excluir</button>
             <button type="button" id="voltar">Voltar</button>
         </div>
     </div>
@@ -34,12 +36,30 @@
             const partes = ['anamnese','composicao','perimetria','flexibilidade','postural'];
             const dadosPartes = partes.map(p => {
                 const dados = localStorage.getItem(`avaliacao_${alunoId}_${avalId}_${p}`);
-                if (dados) return `<h3>${p}</h3><pre>${JSON.stringify(JSON.parse(dados), null, 2)}</pre>`;
+                if (dados) {
+                    const obj = JSON.parse(dados);
+                    const campos = Object.entries(obj).map(([k,v]) => `<div><strong>${k}:</strong> ${v}</div>`).join('');
+                    return `<div class="avaliacao-part"><h3>${p}</h3><div class="avaliacao-grid">${campos}</div></div>`;
+                }
                 return '';
             }).join('');
-            container.innerHTML = `<p>Data: ${new Date(avaliacao.data).toLocaleDateString()}</p>` +
-                `<p>Próxima Avaliação: ${avaliacao.proxima || '-'}</p>` + dadosPartes;
+            container.innerHTML = `<div class="avaliacao-grid"><div><strong>Data:</strong> ${new Date(avaliacao.data).toLocaleDateString()}</div>` +
+                `<div><strong>Próxima Avaliação:</strong> ${avaliacao.proxima || '-'}</div></div>` + dadosPartes;
+
             document.getElementById('voltar').addEventListener('click', () => window.history.back());
+            document.getElementById('editar').addEventListener('click', () => {
+                localStorage.setItem(`currentAvalId_${alunoId}`, avalId);
+                window.location.href = `nova_avaliacao.html?id=${alunoId}`;
+            });
+            document.getElementById('excluir').addEventListener('click', () => {
+                if (confirm('Deseja excluir esta avaliação?')) {
+                    const chave = `avaliacoes_${alunoId}`;
+                    const lista = JSON.parse(localStorage.getItem(chave) || '[]').filter(a => String(a.id) !== avalId);
+                    localStorage.setItem(chave, JSON.stringify(lista));
+                    partes.forEach(p => localStorage.removeItem(`avaliacao_${alunoId}_${avalId}_${p}`));
+                    window.location.href = 'dashboard.html?section=avaliacoes';
+                }
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- allow editing/deleting saved evaluations in the evaluation list
- show saved evaluation details using card layout
- load saved data when opening evaluation forms for editing
- keep next evaluation date when editing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dbfacb9b483239cfec7106ad7a2fb