### PR TITLE
Implement dashboard home layout

### DIFF
--- a/frontend/css/dashboard.css
+++ b/frontend/css/dashboard.css
@@ -75,6 +75,28 @@ body {
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 }
 
+.header-right {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.notifications {
+    position: relative;
+    cursor: pointer;
+}
+
+.notifications .badge {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    background-color: #f58725;
+    color: #000;
+    border-radius: 50%;
+    padding: 2px 6px;
+    font-size: 12px;
+}
+
 #content {
     flex: 1;
     overflow-y: auto;
@@ -409,4 +431,66 @@ body {
     grid-column: span 3;
     display: flex;
     gap: 10px;
+}
+
+/* ===== Dashboard Home ===== */
+.welcome {
+    background-color: #1e1e1e;
+    padding: 20px;
+    border-radius: 6px;
+    margin-bottom: 20px;
+}
+
+.quick-access {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.quick-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 20px;
+    background-color: #1e1e1e;
+    border-radius: 6px;
+    color: #fff;
+    border: 1px solid #333;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.quick-btn i {
+    font-size: 24px;
+    color: #f58725;
+}
+
+.quick-btn:hover {
+    background-color: #2a2a2a;
+}
+
+.day-calendar,
+.students-summary {
+    background-color: #1e1e1e;
+    padding: 20px;
+    border-radius: 6px;
+    margin-bottom: 20px;
+}
+
+.view-month-btn {
+    margin-top: 10px;
+}
+
+.students-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.students-list li {
+    padding: 6px 0;
+    border-bottom: 1px solid #333;
 }

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -33,13 +33,16 @@
         <div class="main">
             <header class="header">
                 <h1><span style="color: #f58725;">Personal</span>Hub</h1>
-                <span id="userGreeting">Olá, Personal</span>
+                <div class="header-right">
+                    <span id="userGreeting">Olá, Personal</span>
+                    <div class="notifications">
+                        <i class="fas fa-bell"></i>
+                        <span class="badge" id="notifCount">0</span>
+                    </div>
+                </div>
             </header>
 
-            <main id="content">
-                <h2>Dashboard</h2>
-                <p>Selecione um módulo no menu lateral.</p>
-            </main>
+            <main id="content"></main>
         </div>
     </div>
 

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -84,3 +84,9 @@ export async function fetchUserRole() {
     const data = await res.json();
     return data.role;
 }
+
+export async function fetchUserInfo() {
+    const res = await fetchWithFreshToken('http://localhost:3000/users/me');
+    if (!res.ok) return null;
+    return await res.json();
+}

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -1,4 +1,4 @@
-import { fetchUserRole } from "./auth.js";
+import { fetchUserRole, fetchUserInfo } from "./auth.js";
 
 let USER_ROLE = 'personal';
 
@@ -21,6 +21,8 @@ document.querySelectorAll(".sidebar li").forEach(item => {
             } else if (section === "meus-treinos") {
                 const { loadMeusTreinos } = await import("./treinos.js");
                 loadMeusTreinos();
+            } else if (section === "home") {
+                loadHomeSection();
             } else {
                 loadSection(section);
             }
@@ -36,6 +38,35 @@ function loadSection(section) {
     content.innerHTML = `<h2>${capitalize(section)}</h2><p>Conteúdo do módulo "${section}" será carregado aqui...</p>`;
 }
 
+function loadHomeSection() {
+    const content = document.getElementById("content");
+    content.innerHTML = `
+        <section class="welcome">
+            <h2 id="welcomeMessage">Bem-vindo!</h2>
+            <p id="daySummary">Você tem 0 avaliações e 0 aulas agendadas hoje.</p>
+        </section>
+        <section class="quick-access">
+            <button class="quick-btn" data-action="novo-aluno"><i class="fas fa-user-plus"></i>Cadastrar novo aluno</button>
+            <button class="quick-btn" data-action="nova-avaliacao"><i class="fas fa-notes-medical"></i>Nova avaliação</button>
+            <button class="quick-btn" data-action="nova-aula"><i class="fas fa-calendar-plus"></i>Nova aula agendada</button>
+            <button class="quick-btn" data-action="fichas"><i class="fas fa-folder-open"></i>Ver fichas dos alunos</button>
+            <button class="quick-btn" data-action="importar"><i class="fas fa-file-import"></i>Importar planilhas</button>
+            <button class="quick-btn" data-action="criar-treino"><i class="fas fa-dumbbell"></i>Criar treino</button>
+        </section>
+        <section class="day-calendar">
+            <h3>Agenda de Hoje</h3>
+            <div class="calendar-placeholder">Sem atividades por enquanto.</div>
+            <button class="view-month-btn">Ver mês completo</button>
+        </section>
+        <section class="students-summary">
+            <h3>Alunos Ativos</h3>
+            <ul class="students-list">
+                <li>Exemplo de Aluno</li>
+            </ul>
+        </section>
+    `;
+}
+
 function capitalize(str) {
     return str.charAt(0).toUpperCase() + str.slice(1);
 }
@@ -43,21 +74,25 @@ function capitalize(str) {
 document.addEventListener('DOMContentLoaded', async () => {
     try {
         USER_ROLE = await fetchUserRole();
+        const userInfo = await fetchUserInfo();
         const greet = document.getElementById('userGreeting');
         if (greet) {
+            let name = userInfo && userInfo.nome ? userInfo.nome : '';
             let roleText = 'Personal';
             if (USER_ROLE === 'admin') {
                 roleText = 'Admin';
             } else if (USER_ROLE === 'aluno') {
                 roleText = 'Aluno';
             }
-            greet.textContent = `Olá, ${roleText}`;
+            greet.textContent = `Olá, ${name || roleText}`;
         }
         const params = new URLSearchParams(window.location.search);
         const sec = params.get('section');
         if (sec) {
             const li = document.querySelector(`.sidebar li[data-section="${sec}"]`);
             if (li) li.click();
+        } else {
+            loadHomeSection();
         }
     } catch (err) {
         console.error('Erro ao obter role:', err);


### PR DESCRIPTION
## Summary
- redesign dashboard page header with notifications
- add dashboard home section with quick access, calendar and students list
- style new dashboard home elements
- expose `fetchUserInfo` helper and load user info on startup

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dc41df6748323be3de1f269ac163e