### PR TITLE
Add modal student selection and new student creation

### DIFF
--- a/frontend/js/alunos.js
+++ b/frontend/js/alunos.js
@@ -10,6 +10,7 @@ export async function loadAlunosSection() {
 
         content.innerHTML = `
             <h2>Meus Alunos</h2>
+            <button id="btnNovoAluno" class="quick-btn">Cadastrar novo aluno</button>
             <input type="text" id="searchAluno" placeholder="Buscar por nome..." />
             <ul id="alunoList">
                 ${alunos.map(aluno => `
@@ -29,6 +30,8 @@ export async function loadAlunosSection() {
             attachAlunoHandlers();
         });
         attachAlunoHandlers();
+        const btnNovo = document.getElementById('btnNovoAluno');
+        if (btnNovo) btnNovo.addEventListener('click', () => showNovoAlunoModal(loadAlunosSection));
     } catch (err) {
         console.error("Erro ao buscar alunos:", err);
         content.innerHTML = `<p style="color:red;">Erro ao carregar alunos</p>`;
@@ -107,6 +110,53 @@ function showEditAlunoForm(aluno) {
             showAlunoDetails(aluno.id);
         } else {
             alert('Erro ao atualizar aluno');
+        }
+    });
+}
+
+export function showNovoAlunoModal(callback) {
+    const modal = document.createElement('div');
+    modal.className = 'modal';
+    modal.innerHTML = `
+        <div class="modal-content">
+            <form id="novoAlunoForm">
+                <h3>Novo Aluno</h3>
+                <input type="text" name="nome" placeholder="Nome" required />
+                <input type="email" name="email" placeholder="Email" />
+                <textarea name="observacoes" placeholder="Observações"></textarea>
+                <div>
+                    <button type="submit">Cadastrar</button>
+                    <button type="button" class="cancelModal">Cancelar</button>
+                </div>
+            </form>
+        </div>`;
+    document.body.appendChild(modal);
+    const remove = () => modal.remove();
+    modal.querySelector('.cancelModal').addEventListener('click', remove);
+    modal.addEventListener('click', e => { if (e.target === modal) remove(); });
+    modal.querySelector('#novoAlunoForm').addEventListener('submit', async e => {
+        e.preventDefault();
+        const form = e.target;
+        const body = {
+            nome: form.nome.value,
+            email: form.email.value,
+            observacoes: form.observacoes.value
+        };
+        try {
+            const res = await fetchWithFreshToken('http://localhost:3000/users/alunos', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body)
+            });
+            if (res.ok) {
+                remove();
+                if (callback) callback();
+            } else {
+                alert('Erro ao cadastrar aluno');
+            }
+        } catch (err) {
+            console.error('Erro ao cadastrar aluno:', err);
+            alert('Erro ao cadastrar aluno');
         }
     });
 }

--- a/frontend/js/treinos.js
+++ b/frontend/js/treinos.js
@@ -9,7 +9,7 @@ let TODOS_EXERCICIOS_OBJ = [];
 let CAT_OPTIONS = '';
 let GRUPO_OPTIONS = '';
 
-export async function loadTreinosSection() {
+export async function loadTreinosSection(alunoIdParam = '') {
     const content = document.getElementById("content");
     content.innerHTML = "<h2>Carregando...</h2>";
     try {
@@ -53,6 +53,8 @@ export async function loadTreinosSection() {
         addDia();
 
         const alunoSel = document.querySelector('#novoTreinoForm select[name="aluno"]');
+        const urlAluno = alunoIdParam || new URLSearchParams(window.location.search).get('aluno') || '';
+        if (urlAluno) alunoSel.value = urlAluno;
         alunoSel.addEventListener('change', () => loadTreinosAluno(alunoSel.value));
         loadTreinosAluno(alunoSel.value);
 


### PR DESCRIPTION
## Summary
- open Treinos with selected student via query param
- update quick-access buttons for dashboard and attach student selection modal
- support modal for choosing students before redirects
- allow creating new students from dashboard and Meus Alunos
- auto-select student when opening Treinos section

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_684dcbf45d0c8323b780df6242ceb696