### PR TITLE
Fix treino AI with anamnese data

### DIFF
--- a/backend/iaService.js
+++ b/backend/iaService.js
@@ -2,14 +2,17 @@ const { InferenceClient } = require('@huggingface/inference');
 const client = new InferenceClient(process.env.HF_TOKEN);
 
 async function gerarTreinoIA(aluno) {
+  const objetivo = aluno.objetivo || aluno.objetivos || '';
+  const frequencia = aluno.frequencia || aluno.frequenciaTreinos || '';
+
   const prompt = `
     Crie um plano de treino semanal para um aluno com os seguintes dados:
-    - Nome: ${aluno.nome}
-    - Idade: ${aluno.idade}
-    - Altura: ${aluno.altura}
-    - Peso: ${aluno.peso}
-    - Objetivo: ${aluno.objetivo}
-    - Frequência semanal: ${aluno.frequencia}x
+    - Nome: ${aluno.nome || ''}
+    - Idade: ${aluno.idade || ''}
+    - Altura: ${aluno.altura || ''}
+    - Peso: ${aluno.peso || ''}
+    - Objetivo: ${objetivo}
+    - Frequência semanal: ${frequencia}x
 
     Liste os exercícios em formato de tabela, com dia da semana, grupo muscular, exercícios, séries e repetições.
   `;

--- a/backend/routes/treino-ia.js
+++ b/backend/routes/treino-ia.js
@@ -22,8 +22,16 @@ router.post('/gerar-ia', verifyToken, async (req, res) => {
     if (!alunoDoc.exists) {
       return res.status(404).json({ error: 'Aluno não encontrado' });
     }
+    const anamneseDoc = await admin.firestore()
+      .collection('users').doc(personalId)
+      .collection('alunos').doc(alunoId)
+      .collection('anamnese').doc('respostas')
+      .get();
 
-    const treino = await gerarTreinoIA(alunoDoc.data());
+    const alunoData = alunoDoc.data();
+    const anamneseData = anamneseDoc.exists ? anamneseDoc.data() : {};
+
+    const treino = await gerarTreinoIA({ ...alunoData, ...anamneseData });
     res.json({ treino });
   } catch (err) {
     console.error('Erro ao gerar treino com IA:', err);


### PR DESCRIPTION
## Summary
- merge anamnese answers with aluno data when generating AI workouts
- allow `gerarTreinoIA` to handle alternate field names

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dfb1341d88323b9c22dae36ee6f68