### PR TITLE
Fix IA training generation using textGeneration

### DIFF
--- a/backend/iaService.js
+++ b/backend/iaService.js
@@ -15,13 +15,14 @@ async function gerarTreinoIA(aluno) {
     `Objetivo: ${objetivo}\n` +
     `Frequencia: ${frequencia}`;
 
-  const chat = await client.chatCompletion({
-    provider: "featherless-ai",
-    model: "mistralai/Magistral-Small-2506",
-    messages: [{ role: "user", content: prompt }],
+  const generation = await client.textGeneration({
+    provider: 'featherless-ai',
+    model: 'mistralai/Magistral-Small-2506',
+    inputs: prompt,
+    parameters: { max_new_tokens: 512 }
   });
 
-  const text = chat.choices?.[0]?.message?.content?.trim() || '';
+  const text = generation.generated_text?.trim() || '';
   let jsonText = text;
 
   const codeBlock = jsonText.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);


### PR DESCRIPTION
## Summary
- use `textGeneration` instead of `chatCompletion` in `gerarTreinoIA`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684e37a8eaa48323945111090bb47ed2