### PR TITLE
Handle AI exercises not in database

### DIFF
--- a/backend/routes/treino-ia.js
+++ b/backend/routes/treino-ia.js
@@ -52,13 +52,13 @@ router.post('/gerar-ia', verifyToken, async (req, res) => {
       if (!Array.isArray(dia.exercicios)) return;
       const exs = [];
       dia.exercicios.forEach(ex => {
-        if (exerciciosValidos.has(ex.nome)) {
-          exs.push({
-            nome: ex.nome,
-            series: ex.series || null,
-            repeticoes: ex.repeticoes || null
-          });
-        }
+        if (!ex.nome) return;
+        exs.push({
+          nome: ex.nome,
+          series: ex.series || null,
+          repeticoes: ex.repeticoes || null,
+          invalido: exerciciosValidos.has(ex.nome) ? undefined : true
+        });
       });
       if (exs.length) {
         diasProcessados.push({

--- a/backend/routes/users/treinos.js
+++ b/backend/routes/users/treinos.js
@@ -179,15 +179,13 @@ router.post('/alunos/:alunoId/gerarTreinoIA', verifyToken, async (req, res) => {
             if (!Array.isArray(dia.exercicios)) return;
             const exs = [];
             dia.exercicios.forEach(ex => {
-                if (exerciciosValidos.has(ex.nome)) {
-                    exs.push({
-                        nome: ex.nome,
-                        series: ex.series || null,
-                        repeticoes: ex.repeticoes || null
-                    });
-                } else {
-                    console.warn(`Exercício não encontrado: ${ex.nome}`);
-                }
+                if (!ex.nome) return;
+                exs.push({
+                    nome: ex.nome,
+                    series: ex.series || null,
+                    repeticoes: ex.repeticoes || null,
+                    invalido: exerciciosValidos.has(ex.nome) ? undefined : true
+                });
             });
             if (exs.length) {
                 diasSalvos.push({


### PR DESCRIPTION
## Summary
- keep AI-suggested exercises even if unknown
- mark unknown exercises so they can be reviewed

## Testing
- `node -c backend/routes/treino-ia.js`
- `node -c backend/routes/users/treinos.js`


------
https://chatgpt.com/codex/tasks/task_e_684e39ccdf548323b38451599ec92d13