### PR TITLE
Add bulk exercise insertion script

### DIFF
--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -1,0 +1,35 @@
+# Scripts de apoio
+
+## bulkAddExercises.js
+
+Script para inserir vários exercícios de uma vez no Firestore.
+
+### Uso
+
+```bash
+node bulkAddExercises.js [arquivo_json] [personalId]
+```
+
+- **arquivo_json**: Caminho para o arquivo contendo o array de exercícios (padrão: `sample-exercises.json`).
+- **personalId**: ID do personal caso queira inserir na coleção de um usuário. Quando omitido, os exercícios são adicionados na coleção global `exerciciosSistema`.
+
+### Exemplo
+
+```bash
+node bulkAddExercises.js sample-exercises.json
+```
+
+### Formato do arquivo JSON
+
+```json
+[
+  {
+    "nome": "Supino Reto",
+    "categoria": "Força",
+    "grupoMuscularPrincipal": "Peito",
+    "gruposMusculares": ["Tríceps", "Ombros"]
+  }
+]
+```
+
+Use `sample-exercises.json` como modelo para criar seus próprios arquivos.

--- a/backend/scripts/bulkAddExercises.js
+++ b/backend/scripts/bulkAddExercises.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const admin = require('../firebase-admin');
+
+const jsonPath = process.argv[2] || path.join(__dirname, 'sample-exercises.json');
+const personalId = process.argv[3];
+
+async function main() {
+  try {
+    const data = fs.readFileSync(jsonPath, 'utf8');
+    const exercises = JSON.parse(data);
+    const db = admin.firestore();
+
+    for (const ex of exercises) {
+      const collection = personalId
+        ? db.collection('users').doc(personalId).collection('exercicios')
+        : db.collection('exerciciosSistema');
+
+      const doc = {
+        nome: ex.nome || '',
+        categoria: ex.categoria || null,
+        grupoMuscularPrincipal: ex.grupoMuscularPrincipal || null,
+        gruposMusculares: Array.isArray(ex.gruposMusculares) ? ex.gruposMusculares : [],
+        criadoEm: new Date().toISOString(),
+      };
+
+      await collection.add(doc);
+      console.log(`Inserido: ${doc.nome}`);
+    }
+
+    console.log('Concluído.');
+    process.exit(0);
+  } catch (err) {
+    console.error('Erro ao inserir exercícios:', err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/backend/scripts/sample-exercises.json
+++ b/backend/scripts/sample-exercises.json
@@ -1,0 +1,14 @@
+[
+  {
+    "nome": "Agachamento",
+    "categoria": "Força",
+    "grupoMuscularPrincipal": "Quadríceps",
+    "gruposMusculares": ["Glúteos", "Posterior de coxa"]
+  },
+  {
+    "nome": "Supino Reto",
+    "categoria": "Força",
+    "grupoMuscularPrincipal": "Peito",
+    "gruposMusculares": ["Tríceps", "Ombros"]
+  }
+]


### PR DESCRIPTION
## Summary
- add a script to insert multiple exercises into Firestore
- provide sample JSON and instructions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684e3e087a148323b175fa377c62e830