### PR TITLE
Implement basic interactive agenda

### DIFF
--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -11,6 +11,7 @@ router.use('/users', require('./users/exercicios'));
 router.use('/users', require('./users/metodos'));
 router.use('/users', require('./users/admin-invite'));
 router.use('/users', require('./users/anamnese'));
+router.use('/users', require('./users/agenda'));
 router.use('/treino', require('./treino-ia'));
 
 

--- a/backend/routes/users/agenda.js
+++ b/backend/routes/users/agenda.js
@@ -1,0 +1,177 @@
+const express = require('express');
+const router = express.Router();
+const admin = require('../../firebase-admin');
+const verifyToken = require('../../middleware/verifyToken');
+
+// === Disponibilidade ===
+router.post('/agenda/disponibilidade', verifyToken, async (req, res) => {
+    const personalId = req.user.uid;
+    const { diaSemana, inicio, fim } = req.body;
+
+    if (diaSemana === undefined || !inicio || !fim) {
+        return res.status(400).json({ error: 'Dados incompletos' });
+    }
+
+    try {
+        const docRef = await admin.firestore()
+            .collection('users').doc(personalId)
+            .collection('disponibilidade')
+            .add({ diaSemana: Number(diaSemana), inicio, fim });
+
+        res.status(201).json({ id: docRef.id });
+    } catch (err) {
+        console.error('Erro ao salvar disponibilidade:', err);
+        res.status(500).json({ error: 'Erro ao salvar disponibilidade' });
+    }
+});
+
+router.get('/agenda/disponibilidade', verifyToken, async (req, res) => {
+    const personalId = req.user.uid;
+    try {
+        const snap = await admin.firestore()
+            .collection('users').doc(personalId)
+            .collection('disponibilidade').get();
+        const itens = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+        res.json(itens);
+    } catch (err) {
+        console.error('Erro ao obter disponibilidade:', err);
+        res.status(500).json({ error: 'Erro ao obter disponibilidade' });
+    }
+});
+
+// === Aulas ===
+router.post('/agenda/aulas', verifyToken, async (req, res) => {
+    let personalId = req.body.personalId || req.user.uid;
+    let { alunoId, inicio, fim, alunoNome, alunoEmail } = req.body;
+
+    if (!inicio || !fim) {
+        return res.status(400).json({ error: 'Horários inválidos' });
+    }
+
+    try {
+        const userDoc = await admin.firestore().collection('users').doc(req.user.uid).get();
+        const role = userDoc.exists ? userDoc.data().role : 'personal';
+
+        if (role === 'aluno') {
+            // busca personal pelo email do aluno
+            const snap = await admin.firestore()
+                .collectionGroup('alunos')
+                .where('email', '==', req.user.email)
+                .limit(1)
+                .get();
+            if (snap.empty) return res.status(404).json({ error: 'Personal não encontrado' });
+            const doc = snap.docs[0];
+            personalId = doc.ref.parent.parent.id;
+            alunoId = doc.id;
+            alunoNome = doc.data().nome;
+            alunoEmail = req.user.email;
+        }
+
+        // Limite de 2 aulas por semana
+        const inicioDate = new Date(inicio);
+        const semanaInicio = new Date(inicioDate);
+        semanaInicio.setUTCHours(0,0,0,0);
+        semanaInicio.setUTCDate(inicioDate.getUTCDate() - inicioDate.getUTCDay());
+        const semanaFim = new Date(semanaInicio);
+        semanaFim.setUTCDate(semanaFim.getUTCDate() + 7);
+
+        const semanaSnap = await admin.firestore()
+            .collection('users').doc(personalId)
+            .collection('agenda')
+            .where('alunoId', '==', alunoId)
+            .where('inicio', '>=', semanaInicio.toISOString())
+            .where('inicio', '<', semanaFim.toISOString())
+            .get();
+        if (semanaSnap.size >= 2) {
+            return res.status(400).json({ error: 'Limite semanal atingido' });
+        }
+
+        const docRef = await admin.firestore()
+            .collection('users').doc(personalId)
+            .collection('agenda').add({
+                tipo: 'aula',
+                alunoId: alunoId || null,
+                alunoNome: alunoNome || null,
+                alunoEmail: alunoEmail || null,
+                inicio,
+                fim,
+                status: 'agendada',
+                createdAt: new Date().toISOString()
+            });
+        res.status(201).json({ id: docRef.id });
+    } catch (err) {
+        console.error('Erro ao agendar aula:', err);
+        res.status(500).json({ error: 'Erro ao agendar aula' });
+    }
+});
+
+router.get('/agenda/aulas', verifyToken, async (req, res) => {
+    const { inicio, fim, aluno } = req.query;
+    const uid = req.user.uid;
+    try {
+        const userDoc = await admin.firestore().collection('users').doc(uid).get();
+        const role = userDoc.exists ? userDoc.data().role : 'personal';
+
+        let query;
+        if (role === 'personal') {
+            query = admin.firestore().collection('users').doc(uid).collection('agenda');
+            if (aluno) query = query.where('alunoId', '==', aluno);
+        } else {
+            query = admin.firestore().collectionGroup('agenda').where('alunoEmail', '==', req.user.email);
+        }
+        if (inicio) query = query.where('inicio', '>=', inicio);
+        if (fim) query = query.where('inicio', '<=', fim);
+        const snap = await query.get();
+        const eventos = snap.docs.map(d => ({ id: d.id, personalId: d.ref.parent.parent.id, ...d.data() }));
+        res.json(eventos);
+    } catch (err) {
+        console.error('Erro ao listar aulas:', err);
+        res.status(500).json({ error: 'Erro ao listar aulas' });
+    }
+});
+
+router.put('/agenda/aulas/:id', verifyToken, async (req, res) => {
+    const uid = req.user.uid;
+    const aulaId = req.params.id;
+    const { status, feedback } = req.body;
+
+    try {
+        const userDoc = await admin.firestore().collection('users').doc(uid).get();
+        const role = userDoc.exists ? userDoc.data().role : 'personal';
+
+        let docRef;
+        if (role === 'personal') {
+            docRef = admin.firestore().collection('users').doc(uid).collection('agenda').doc(aulaId);
+        } else {
+            const snap = await admin.firestore()
+                .collectionGroup('agenda')
+                .where('alunoEmail', '==', req.user.email)
+                .where(admin.firestore.FieldPath.documentId(), '==', aulaId)
+                .limit(1)
+                .get();
+            if (snap.empty) return res.status(404).json({ error: 'Aula não encontrada' });
+            docRef = snap.docs[0].ref;
+        }
+        const doc = await docRef.get();
+        if (!doc.exists) return res.status(404).json({ error: 'Aula não encontrada' });
+
+        if (role === 'aluno' && status === 'cancelada') {
+            const inicioAula = new Date(doc.data().inicio);
+            if (Date.now() > inicioAula.getTime() - 2 * 60 * 60 * 1000) {
+                return res.status(400).json({ error: 'Só é possível cancelar com 2h de antecedência' });
+            }
+        }
+
+        const update = {};
+        if (status) update.status = status;
+        if (feedback !== undefined) update.feedback = feedback;
+        update.updatedAt = new Date().toISOString();
+        await docRef.update(update);
+        res.json({ message: 'Atualizado' });
+    } catch (err) {
+        console.error('Erro ao atualizar aula:', err);
+        res.status(500).json({ error: 'Erro ao atualizar aula' });
+    }
+});
+
+module.exports = router;

--- a/frontend/css/dashboard.css
+++ b/frontend/css/dashboard.css
@@ -494,3 +494,58 @@ body {
     padding: 6px 0;
     border-bottom: 1px solid #333;
 }
+
+/* ===== Agenda ===== */
+.agenda-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+.calendario {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.cal-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 4px;
+}
+
+.cal-head {
+    text-align: center;
+    font-weight: bold;
+    padding-bottom: 4px;
+}
+
+.cal-cell {
+    min-height: 80px;
+    background-color: #1e1e1e;
+    border-radius: 4px;
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+    font-size: 12px;
+}
+
+.cal-dia {
+    font-weight: bold;
+    margin-bottom: 4px;
+}
+
+.evt {
+    padding: 2px 4px;
+    border-radius: 4px;
+    margin-bottom: 2px;
+    color: #000;
+    font-size: 11px;
+}
+.agendada { background-color: #f58725; }
+.realizada { background-color: #4caf50; }
+.cancelada { background-color: #f44336; }
+.disponibilidade { background-color: #2196f3; }
+.bloqueado { background-color: #757575; }

--- a/frontend/js/agenda.js
+++ b/frontend/js/agenda.js
@@ -1,0 +1,118 @@
+import { fetchWithFreshToken } from "./auth.js";
+
+export async function loadAgendaSection(alunoParam = '') {
+    const content = document.getElementById('content');
+    content.innerHTML = '<h2>Carregando agenda...</h2>';
+
+    const hoje = new Date();
+    let currentMonth = new Date(Date.UTC(hoje.getUTCFullYear(), hoje.getUTCMonth(), 1));
+
+    async function render() {
+        const inicio = new Date(currentMonth);
+        const fim = new Date(Date.UTC(currentMonth.getUTCFullYear(), currentMonth.getUTCMonth() + 1, 0));
+        const url = `http://localhost:3000/users/agenda/aulas?inicio=${inicio.toISOString()}&fim=${fim.toISOString()}` + (alunoParam ? `&aluno=${alunoParam}` : '');
+        const resp = await fetchWithFreshToken(url);
+        const eventos = await resp.json();
+        content.innerHTML = `
+            <h2>Agenda</h2>
+            <div class="agenda-controls">
+                <button id="prevMes">&#9664;</button>
+                <span id="mesAtual"></span>
+                <button id="nextMes">&#9654;</button>
+            </div>
+            <div id="calendario" class="calendario"></div>
+            <button id="novoAgendamento">Novo agendamento</button>
+        `;
+        document.getElementById('prevMes').addEventListener('click', () => { currentMonth.setUTCMonth(currentMonth.getUTCMonth() - 1); render(); });
+        document.getElementById('nextMes').addEventListener('click', () => { currentMonth.setUTCMonth(currentMonth.getUTCMonth() + 1); render(); });
+        document.getElementById('novoAgendamento').addEventListener('click', showNovoAgendamentoModal);
+        document.getElementById('mesAtual').textContent = currentMonth.toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' });
+        desenharCalendario(inicio, fim, eventos);
+    }
+
+    async function showNovoAgendamentoModal() {
+        try {
+            const resp = await fetchWithFreshToken('http://localhost:3000/users/alunos');
+            const alunos = await resp.json();
+            const modal = document.createElement('div');
+            modal.className = 'modal';
+            modal.innerHTML = `
+                <div class="modal-content">
+                    <h3>Novo Agendamento</h3>
+                    <form id="formAgendamento">
+                        <select name="aluno" required>
+                            <option value="">Selecione o aluno</option>
+                            ${alunos.map(a => `<option value="${a.id}">${a.nome}</option>`).join('')}
+                        </select>
+                        <input type="date" name="dia" required />
+                        <input type="time" name="inicio" required />
+                        <input type="time" name="fim" required />
+                        <div>
+                            <button type="submit">Agendar</button>
+                            <button type="button" class="cancelModal">Cancelar</button>
+                        </div>
+                    </form>
+                </div>`;
+            document.body.appendChild(modal);
+            const remove = () => modal.remove();
+            modal.addEventListener('click', e => { if (e.target === modal) remove(); });
+            modal.querySelector('.cancelModal').addEventListener('click', remove);
+            modal.querySelector('#formAgendamento').addEventListener('submit', async e => {
+                e.preventDefault();
+                const form = e.target;
+                const dia = form.dia.value;
+                const inicio = `${dia}T${form.inicio.value}:00.000Z`;
+                const fim = `${dia}T${form.fim.value}:00.000Z`;
+                const body = { alunoId: form.aluno.value, inicio, fim };
+                const r = await fetchWithFreshToken('http://localhost:3000/users/agenda/aulas', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body)
+                });
+                if (r.ok) {
+                    remove();
+                    render();
+                } else {
+                    alert('Erro ao agendar aula');
+                }
+            });
+        } catch (err) {
+            console.error('Erro ao abrir modal:', err);
+        }
+    }
+
+    function desenharCalendario(inicio, fim, eventos) {
+        const cal = document.getElementById('calendario');
+        cal.innerHTML = '';
+        const diasNoMes = fim.getUTCDate();
+        const primeiroDiaSemana = new Date(inicio).getUTCDay();
+        const grid = document.createElement('div');
+        grid.className = 'cal-grid';
+        cal.appendChild(grid);
+        const nomesDias = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sab'];
+        nomesDias.forEach(n => {
+            const h = document.createElement('div');
+            h.className = 'cal-head';
+            h.textContent = n;
+            grid.appendChild(h);
+        });
+        for (let i = 0; i < primeiroDiaSemana; i++) {
+            grid.appendChild(document.createElement('div'));
+        }
+        for (let dia = 1; dia <= diasNoMes; dia++) {
+            const cell = document.createElement('div');
+            cell.className = 'cal-cell';
+            cell.innerHTML = `<span class="cal-dia">${dia}</span>`;
+            const dataStr = new Date(Date.UTC(inicio.getUTCFullYear(), inicio.getUTCMonth(), dia)).toISOString().substring(0,10);
+            eventos.filter(ev => ev.inicio.startsWith(dataStr)).forEach(ev => {
+                const div = document.createElement('div');
+                div.className = `evt ${ev.status || ev.tipo}`;
+                div.textContent = ev.alunoNome || ev.tipo;
+                cell.appendChild(div);
+            });
+            grid.appendChild(cell);
+        }
+    }
+
+    render();
+}

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -13,12 +13,16 @@ document.querySelectorAll(".sidebar li").forEach(item => {
                 const { loadTreinosSection } = await import("./treinos.js");
                 const aluno = new URLSearchParams(window.location.search).get('aluno') || '';
                 loadTreinosSection(aluno);
-            } else if (section === "exercicios") {
-                const { loadExerciciosSection } = await import("./exercicios.js");
-                loadExerciciosSection();
-            } else if (section === "avaliacoes") {
-                const { loadAvaliacoesSection } = await import("./avaliacoes.js");
-                loadAvaliacoesSection();
+           } else if (section === "exercicios") {
+               const { loadExerciciosSection } = await import("./exercicios.js");
+               loadExerciciosSection();
+           } else if (section === "avaliacoes") {
+               const { loadAvaliacoesSection } = await import("./avaliacoes.js");
+               loadAvaliacoesSection();
+            } else if (section === "agenda") {
+                const { loadAgendaSection } = await import("./agenda.js");
+                const aluno = new URLSearchParams(window.location.search).get('aluno') || '';
+                loadAgendaSection(aluno);
             } else if (section === "meus-treinos") {
                 const { loadMeusTreinos } = await import("./treinos.js");
                 loadMeusTreinos();


### PR DESCRIPTION
## Summary
- add agenda API routes for scheduling and availability
- mount agenda routes in router
- load agenda section from dashboard and implement calendar rendering
- style agenda calendar elements

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855bc8e0c4c832387dff65eb8ee85b7