### PR TITLE
Fix calendar dates and show next classes

### DIFF
--- a/frontend/css/dashboard.css
+++ b/frontend/css/dashboard.css
@@ -495,6 +495,17 @@ body {
     border-bottom: 1px solid #333;
 }
 
+.lista-aulas {
+    list-style: none;
+    padding: 0;
+    margin-top: 10px;
+}
+
+.lista-aulas li {
+    padding: 6px 0;
+    border-bottom: 1px solid #333;
+}
+
 /* ===== Agenda ===== */
 .agenda-controls {
     display: flex;


### PR DESCRIPTION
## Summary
- fix agenda date handling by using local time calculations
- add list of upcoming classes under the calendar
- style list of upcoming classes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68569e18383083239e8dcd48b4e32445