### PR TITLE
Improve agenda scheduling and availability editing

### DIFF
--- a/frontend/css/dashboard.css
+++ b/frontend/css/dashboard.css
@@ -575,6 +575,18 @@ body {
 
 .dia-semana {
     display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+}
+
+.dia-semana label {
+    display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 4px;
+}
+
+.hora-container {
+    display: flex;
+    gap: 6px;
 }


### PR DESCRIPTION
## Summary
- update disponibilidade modal with start/end times per weekday
- allow editing of specific-day availability items
- show available time slots when scheduling a class
- style availability modal inputs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856a53e388883239f54e99ea82b6ff3