### PR TITLE
Implement basic plans and personal page routes

### DIFF
--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -12,6 +12,8 @@ router.use('/users', require('./users/metodos'));
 router.use('/users', require('./users/admin-invite'));
 router.use('/users', require('./users/anamnese'));
 router.use('/users', require('./users/agenda'));
+router.use('/users', require('./users/personal-page'));
+router.use('/public', require('./public'));
 router.use('/treino', require('./treino-ia'));
 
 

--- a/backend/routes/public.js
+++ b/backend/routes/public.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const router = express.Router();
+const admin = require('../firebase-admin');
+
+router.get('/personal/:slug', async (req, res) => {
+    const { slug } = req.params;
+    try {
+        const snap = await admin.firestore()
+            .collection('users')
+            .where('page.slug', '==', slug)
+            .limit(1)
+            .get();
+        if (snap.empty) return res.status(404).json({ error: 'Personal não encontrado' });
+        const page = snap.docs[0].data().page || {};
+        res.json(page);
+    } catch (err) {
+        console.error('Erro ao buscar página pública:', err);
+        res.status(500).json({ error: 'Erro ao buscar página' });
+    }
+});
+
+module.exports = router;

--- a/backend/routes/users/personal-page.js
+++ b/backend/routes/users/personal-page.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const router = express.Router();
+const admin = require('../../firebase-admin');
+const verifyToken = require('../../middleware/verifyToken');
+
+router.get('/personal-page', verifyToken, async (req, res) => {
+    const uid = req.user.uid;
+    try {
+        const doc = await admin.firestore().collection('users').doc(uid).get();
+        if (!doc.exists) return res.status(404).json({ error: 'Usuário não encontrado' });
+        res.json(doc.data().page || {});
+    } catch (err) {
+        console.error('Erro ao obter página:', err);
+        res.status(500).json({ error: 'Erro ao obter página' });
+    }
+});
+
+router.put('/personal-page', verifyToken, async (req, res) => {
+    const uid = req.user.uid;
+    const { slug, displayName, photoUrl, description, planos } = req.body;
+    const page = { slug, displayName, photoUrl, description, planos };
+    try {
+        await admin.firestore().collection('users').doc(uid).set({ page }, { merge: true });
+        res.json({ message: 'Página atualizada' });
+    } catch (err) {
+        console.error('Erro ao salvar página:', err);
+        res.status(500).json({ error: 'Erro ao salvar página' });
+    }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- allow customizing and fetching personal landing pages
- store plan info for students
- adapt schedule limit check per student's plan
- expose a public route to get personal pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856aff0d8ac8323b4bb5d77ffbc3894