### PR TITLE
Fix firebase admin credential handling

### DIFF
--- a/backend/firebase-admin.js
+++ b/backend/firebase-admin.js
@@ -1,7 +1,28 @@
 const admin = require('firebase-admin');
-const serviceAccount = require('./serviceAccountKey.json');
+const fs = require('fs');
+const path = require('path');
+
+let credentials;
+
+// Permite carregar as credenciais via variável de ambiente ou arquivo local
+if (process.env.FIREBASE_SERVICE_ACCOUNT) {
+    try {
+        credentials = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
+    } catch (err) {
+        console.error('FIREBASE_SERVICE_ACCOUNT inválida');
+        throw err;
+    }
+} else {
+    const keyPath = path.join(__dirname, 'serviceAccountKey.json');
+    if (fs.existsSync(keyPath)) {
+        credentials = require(keyPath);
+    } else {
+        throw new Error('Credenciais do Firebase não encontradas');
+    }
+}
 
 admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
+    credential: admin.credential.cert(credentials)
 });
+
 module.exports = admin;


### PR DESCRIPTION
## Summary
- allow specifying Firebase credentials via `FIREBASE_SERVICE_ACCOUNT`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f563fa2408323951b14aac186c835