### PR TITLE
Fix Firebase credential loading

### DIFF
--- a/backend/firebase-admin.js
+++ b/backend/firebase-admin.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 let credentials;
 
+
 // Permite carregar as credenciais via variável de ambiente ou arquivo local
 if (process.env.FIREBASE_SERVICE_ACCOUNT) {
     try {
@@ -12,6 +13,12 @@ if (process.env.FIREBASE_SERVICE_ACCOUNT) {
         console.error('FIREBASE_SERVICE_ACCOUNT inválida');
         throw err;
     }
+} else if (process.env.project_id && process.env.private_key && process.env.client_email) {
+    credentials = {
+        project_id: process.env.project_id,
+        private_key: process.env.private_key.replace(/\\n/g, '\n'),
+        client_email: process.env.client_email
+    };
 } else {
     const keyPath = path.join(__dirname, 'serviceAccountKey.json');
     if (fs.existsSync(keyPath)) {


### PR DESCRIPTION
## Summary
- allow reading Firebase credentials from the `project_id`, `private_key`, and `client_email` env vars when `FIREBASE_SERVICE_ACCOUNT` is not set

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f606411308323bbd8823678ea2d02