### PR TITLE
Implement detailed student profile view

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -625,3 +625,57 @@ body {
     display: flex;
     gap: 6px;
 }
+
+/* === Perfil do Aluno === */
+.aluno-perfil {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.dados-pessoais {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    background-color: #1e1e1e;
+    padding: 15px;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.5);
+}
+
+.dados-pessoais img {
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.perfil-section {
+    background-color: #1e1e1e;
+    padding: 15px;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.5);
+}
+
+.perfil-section h3 {
+    margin-top: 0;
+    color: #f58725;
+}
+
+.avaliacoes-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+
+.avaliacoes-table th,
+.avaliacoes-table td {
+    padding: 6px;
+    border-bottom: 1px solid #333;
+    text-align: left;
+}
+
+.perfil-actions {
+    display: flex;
+    gap: 10px;
+}

--- a/public/js/alunos.js
+++ b/public/js/alunos.js
@@ -44,6 +44,48 @@ function attachAlunoHandlers() {
     });
 }
 
+function calcularIdade(data) {
+    if (!data) return '';
+    const nasc = new Date(data);
+    const hoje = new Date();
+    let idade = hoje.getFullYear() - nasc.getFullYear();
+    const m = hoje.getMonth() - nasc.getMonth();
+    if (m < 0 || (m === 0 && hoje.getDate() < nasc.getDate())) idade--;
+    return idade;
+}
+
+function getAvaliacoesResumo(alunoId) {
+    const lista = JSON.parse(localStorage.getItem(`avaliacoes_${alunoId}`) || '[]');
+    return lista.map(a => {
+        const comp = JSON.parse(localStorage.getItem(`avaliacao_${alunoId}_${a.id}_composicao`) || '{}');
+        const peso = comp.peso || '';
+        const altura = comp.altura || '';
+        const imc = peso && altura ? (Number(peso) / ((Number(altura) / 100) ** 2)).toFixed(2) : '';
+        return {
+            data: a.data,
+            peso,
+            altura,
+            imc,
+            gordura: comp.gordura || comp.percentualGordura || '',
+            fc: comp.fcRepouso || comp.fc || ''
+        };
+    }).sort((a,b)=>new Date(b.data)-new Date(a.data));
+}
+
+function renderAvalRow(a) {
+    return `<tr><td>${new Date(a.data).toLocaleDateString()}</td><td>${a.peso || '-'}</td><td>${a.altura || '-'}</td><td>${a.imc || '-'}</td><td>${a.gordura || '-'}</td><td>${a.fc || '-'}</td></tr>`;
+}
+
+async function fetchHistoricoTreinos(alunoId) {
+    try {
+        const res = await fetchWithFreshToken(`/api/users/alunos/${alunoId}/treinos`);
+        if (res.ok) return await res.json();
+    } catch (err) {
+        console.error('Erro ao buscar treinos:', err);
+    }
+    return [];
+}
+
 async function showAlunoDetails(id) {
     const content = document.getElementById('content');
     content.innerHTML = '<h2>Carregando...</h2>';
@@ -52,13 +94,72 @@ async function showAlunoDetails(id) {
         if (!res.ok) throw new Error('Erro ao buscar aluno');
         const aluno = await res.json();
 
+        const idade = calcularIdade(aluno.dataNascimento);
+        const avaliacoes = getAvaliacoesResumo(id);
+        const treinos = await fetchHistoricoTreinos(id);
+        const modalRows = avaliacoes.map(a => renderAvalRow(a)).join('') || '<tr><td colspan="6">Nenhuma avaliação</td></tr>';
+        const tableRows = avaliacoes.slice(0, 3).map(a => renderAvalRow(a)).join('') || '<tr><td colspan="6">Nenhuma avaliação</td></tr>';
+
         content.innerHTML = `
-            <h2>${aluno.nome}</h2>
-            <p><strong>Email:</strong> ${aluno.email || ''}</p>
-            <p><strong>Observações:</strong> ${aluno.observacoes || ''}</p>
-            <button id="editAluno">Editar</button>
-            <button id="deleteAluno">Remover</button>
-            <button id="voltarAlunos">Voltar</button>
+            <div class="aluno-perfil">
+                <div class="dados-pessoais">
+                    <img src="${aluno.fotoUrl || './img/profile-placeholder.png'}" alt="Foto do aluno">
+                    <div>
+                        <h2>${aluno.nome || ''}</h2>
+                        <div class="aluno-cards">
+                            ${idade ? `<span class="info-card">${idade} anos</span>` : ''}
+                            ${aluno.sexo ? `<span class="info-card">${aluno.sexo}</span>` : ''}
+                        </div>
+                        <p>${aluno.telefone || ''}</p>
+                        <p>${aluno.email || ''}</p>
+                    </div>
+                </div>
+
+                <section class="perfil-section">
+                    <h3>Histórico de Avaliações Físicas e de Saúde</h3>
+                    <table class="avaliacoes-table">
+                        <thead>
+                            <tr><th>Data</th><th>Peso</th><th>Altura</th><th>IMC</th><th>% Gordura</th><th>FC Repouso</th></tr>
+                        </thead>
+                        <tbody id="tableAvalResumo">${tableRows}</tbody>
+                    </table>
+                    <button id="abrirHistCompleto">Ver histórico completo</button>
+                </section>
+
+                <section class="perfil-section">
+                    <h3>Objetivos</h3>
+                    <p><strong>Objetivo principal:</strong> ${aluno.objetivo || ''}</p>
+                    <p><strong>Metas específicas:</strong> ${aluno.metas || ''}</p>
+                    <p><strong>Prazo:</strong> ${aluno.prazoMeta || ''}</p>
+                    <p>${aluno.motivacao || ''}</p>
+                </section>
+
+                <section class="perfil-section">
+                    <h3>Histórico de Treinos</h3>
+                    <div id="treinosHist">
+                        ${treinos.map(t => `<div><strong>${new Date(t.criadoEm).toLocaleDateString()}</strong> - ${t.nome}</div>`).join('') || '<p>Nenhum treino cadastrado.</p>'}
+                    </div>
+                </section>
+
+                <div class="perfil-actions">
+                    <button id="editAluno">Editar</button>
+                    <button id="deleteAluno">Remover</button>
+                    <button id="voltarAlunos">Voltar</button>
+                </div>
+            </div>
+
+            <div id="histCompletoModal" class="modal hidden">
+                <div class="modal-content">
+                    <h3>Histórico Completo de Avaliações</h3>
+                    <table class="avaliacoes-table">
+                        <thead>
+                            <tr><th>Data</th><th>Peso</th><th>Altura</th><th>IMC</th><th>% Gordura</th><th>FC Repouso</th></tr>
+                        </thead>
+                        <tbody>${modalRows}</tbody>
+                    </table>
+                    <button class="fecharModal">Fechar</button>
+                </div>
+            </div>
         `;
 
         document.getElementById('editAluno').addEventListener('click', () => showEditAlunoForm(aluno));
@@ -73,6 +174,12 @@ async function showAlunoDetails(id) {
             }
         });
         document.getElementById('voltarAlunos').addEventListener('click', loadAlunosSection);
+        document.getElementById('abrirHistCompleto').addEventListener('click', () => {
+            document.getElementById('histCompletoModal').classList.remove('hidden');
+        });
+        document.querySelector('#histCompletoModal .fecharModal').addEventListener('click', () => {
+            document.getElementById('histCompletoModal').classList.add('hidden');
+        });
     } catch (err) {
         console.error(err);
         content.innerHTML = '<p style="color:red;">Erro ao carregar aluno</p>';


### PR DESCRIPTION
## Summary
- build new student profile layout in aluno view
- show personal data, goal info, evaluation history and training history
- add modal for full evaluation history
- style profile sections in dashboard CSS

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685ff4e9c0948323a81583bcf8922650