### PR TITLE
Enable editing of full student profile and ficha configuration

### DIFF
--- a/backend/routes/users/alunos.js
+++ b/backend/routes/users/alunos.js
@@ -5,7 +5,20 @@ const verifyToken = require('../../middleware/verifyToken');
 
 // Criar aluno
 router.post('/alunos', verifyToken, async (req, res) => {
-    const { nome, email, observacoes, aulasPorSemana } = req.body;
+    const {
+        nome,
+        email,
+        observacoes,
+        aulasPorSemana,
+        fotoUrl,
+        telefone,
+        dataNascimento,
+        sexo,
+        objetivo,
+        metas,
+        prazoMeta,
+        motivacao
+    } = req.body;
     const personalId = req.user.uid;
 
     try {
@@ -18,6 +31,14 @@ router.post('/alunos', verifyToken, async (req, res) => {
                 email,
                 observacoes,
                 aulasPorSemana: aulasPorSemana || 2,
+                fotoUrl: fotoUrl || null,
+                telefone: telefone || null,
+                dataNascimento: dataNascimento || null,
+                sexo: sexo || null,
+                objetivo: objetivo || null,
+                metas: metas || null,
+                prazoMeta: prazoMeta || null,
+                motivacao: motivacao || null,
                 criadoEm: new Date().toISOString()
             });
 
@@ -85,7 +106,20 @@ router.get('/alunos/:id', verifyToken, async (req, res) => {
 router.put('/alunos/:id', verifyToken, async (req, res) => {
     const personalId = req.user.uid;
     const alunoId = req.params.id;
-    const { nome, email, observacoes, aulasPorSemana } = req.body;
+    const {
+        nome,
+        email,
+        observacoes,
+        aulasPorSemana,
+        fotoUrl,
+        telefone,
+        dataNascimento,
+        sexo,
+        objetivo,
+        metas,
+        prazoMeta,
+        motivacao
+    } = req.body;
 
     try {
         const alunoRef = admin.firestore()
@@ -99,6 +133,14 @@ router.put('/alunos/:id', verifyToken, async (req, res) => {
         if (email !== undefined) updateData.email = email;
         if (observacoes !== undefined) updateData.observacoes = observacoes;
         if (aulasPorSemana !== undefined) updateData.aulasPorSemana = aulasPorSemana;
+        if (fotoUrl !== undefined) updateData.fotoUrl = fotoUrl;
+        if (telefone !== undefined) updateData.telefone = telefone;
+        if (dataNascimento !== undefined) updateData.dataNascimento = dataNascimento;
+        if (sexo !== undefined) updateData.sexo = sexo;
+        if (objetivo !== undefined) updateData.objetivo = objetivo;
+        if (metas !== undefined) updateData.metas = metas;
+        if (prazoMeta !== undefined) updateData.prazoMeta = prazoMeta;
+        if (motivacao !== undefined) updateData.motivacao = motivacao;
 
         await alunoRef.update(updateData);
         res.status(200).json({ message: 'Aluno atualizado' });

--- a/backend/routes/users/treinos.js
+++ b/backend/routes/users/treinos.js
@@ -7,7 +7,7 @@ const verifyToken = require('../../middleware/verifyToken');
 router.post('/alunos/:alunoId/treinos', verifyToken, async (req, res) => {
     const personalId = req.user.uid;
     const alunoId = req.params.alunoId;
-    const { nome, dias } = req.body;
+    const { nome, dias, qtdTreinos, proximoTreino, vencimento } = req.body;
 
     try {
         const treinoRef = await admin.firestore()
@@ -17,6 +17,9 @@ router.post('/alunos/:alunoId/treinos', verifyToken, async (req, res) => {
             .add({
                 nome: nome || 'Treino',
                 dias: Array.isArray(dias) ? dias : [],
+                qtdTreinos: qtdTreinos ? parseInt(qtdTreinos) : 1,
+                proximoTreino: proximoTreino || null,
+                vencimento: vencimento || null,
                 criadoEm: new Date().toISOString()
             });
 
@@ -50,11 +53,14 @@ router.get('/alunos/:alunoId/treinos', verifyToken, async (req, res) => {
 router.put('/alunos/:alunoId/treinos/:id', verifyToken, async (req, res) => {
     const personalId = req.user.uid;
     const { alunoId, id } = req.params;
-    const { nome, dias } = req.body;
+    const { nome, dias, qtdTreinos, proximoTreino, vencimento } = req.body;
 
     const updateData = {};
     if (nome !== undefined) updateData.nome = nome;
     if (dias !== undefined) updateData.dias = Array.isArray(dias) ? dias : [];
+    if (qtdTreinos !== undefined) updateData.qtdTreinos = parseInt(qtdTreinos);
+    if (proximoTreino !== undefined) updateData.proximoTreino = proximoTreino;
+    if (vencimento !== undefined) updateData.vencimento = vencimento;
 
     try {
         const docRef = admin.firestore()

--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -679,3 +679,22 @@ body {
     display: flex;
     gap: 10px;
 }
+
+.config-ficha {
+    background-color: #1e1e1e;
+    padding: 15px;
+    border-radius: 6px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+
+.config-ficha label {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+.config-ficha input[type="number"] {
+    width: 60px;
+}

--- a/public/js/alunos.js
+++ b/public/js/alunos.js
@@ -193,6 +193,14 @@ function showEditAlunoForm(aluno) {
         <form id="editAlunoForm">
             <input type="text" name="nome" value="${aluno.nome || ''}" placeholder="Nome" />
             <input type="email" name="email" value="${aluno.email || ''}" placeholder="Email" />
+            <input type="text" name="telefone" value="${aluno.telefone || ''}" placeholder="Telefone" />
+            <input type="date" name="dataNascimento" value="${aluno.dataNascimento || ''}" />
+            <input type="text" name="sexo" value="${aluno.sexo || ''}" placeholder="Sexo" />
+            <input type="text" name="fotoUrl" value="${aluno.fotoUrl || ''}" placeholder="URL da foto" />
+            <textarea name="objetivo" placeholder="Objetivo">${aluno.objetivo || ''}</textarea>
+            <textarea name="metas" placeholder="Metas">${aluno.metas || ''}</textarea>
+            <input type="text" name="prazoMeta" value="${aluno.prazoMeta || ''}" placeholder="Prazo" />
+            <textarea name="motivacao" placeholder="Motivação">${aluno.motivacao || ''}</textarea>
             <textarea name="observacoes" placeholder="Observações">${aluno.observacoes || ''}</textarea>
             <button type="submit">Salvar</button>
             <button type="button" id="cancelEdit">Cancelar</button>
@@ -206,6 +214,14 @@ function showEditAlunoForm(aluno) {
         const data = {
             nome: form.nome.value,
             email: form.email.value,
+            telefone: form.telefone.value,
+            dataNascimento: form.dataNascimento.value,
+            sexo: form.sexo.value,
+            fotoUrl: form.fotoUrl.value,
+            objetivo: form.objetivo.value,
+            metas: form.metas.value,
+            prazoMeta: form.prazoMeta.value,
+            motivacao: form.motivacao.value,
             observacoes: form.observacoes.value
         };
         const res = await fetchWithFreshToken(`/api/users/alunos/${aluno.id}`, {


### PR DESCRIPTION
## Summary
- allow all student profile fields to be edited
- extend backend to store extra student data
- add configuration block to training form for quantity, next workout and due date
- support new fields when creating or editing workouts
- style configuration card

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860432628408323853fe56b99267f85