### PR TITLE
feat(agenda): add busy slot support

### DIFF
--- a/public/js/agenda.js
+++ b/public/js/agenda.js
@@ -1,6 +1,6 @@
 import { fetchWithFreshToken } from "./auth.js";
 
-export async function loadAgendaSection(alunoParam = '') {
+export async function loadAgendaSection(alunoParam = '', incluirOcupado = false) {
     const content = document.getElementById('content');
     content.innerHTML = '<h2>Carregando agenda...</h2>';
 
@@ -10,7 +10,9 @@ export async function loadAgendaSection(alunoParam = '') {
     async function render() {
         const inicio = new Date(currentMonth);
         const fim = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0);
-        const url = `/api/users/agenda/aulas?inicio=${inicio.toISOString()}&fim=${fim.toISOString()}` + (alunoParam ? `&aluno=${alunoParam}` : '');
+        const url = `/api/users/agenda/aulas?inicio=${inicio.toISOString()}&fim=${fim.toISOString()}`
+            + (alunoParam ? `&aluno=${alunoParam}` : '')
+            + (incluirOcupado ? '&incluirOcupado=true' : '');
         const [respAulas, respDisp] = await Promise.all([
             fetchWithFreshToken(url),
             fetchWithFreshToken('/api/users/agenda/disponibilidade')
@@ -312,7 +314,8 @@ export async function loadAgendaSection(alunoParam = '') {
             eventos.filter(ev => ev.inicio.startsWith(dataStr)).forEach(ev => {
                 const div = document.createElement('div');
                 div.className = `evt ${ev.status || ev.tipo}`;
-                div.textContent = ev.alunoNome || ev.tipo;
+                const label = ev.alunoNome || (ev.tipo === 'ocupado' ? 'Ocupado' : ev.tipo);
+                div.textContent = label;
                 cell.appendChild(div);
             });
             grid.appendChild(cell);

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -22,7 +22,8 @@ document.querySelectorAll(".sidebar li").forEach(item => {
             } else if (section === "agenda") {
                 const { loadAgendaSection } = await import("./agenda.js");
                 const aluno = new URLSearchParams(window.location.search).get('aluno') || '';
-                loadAgendaSection(aluno);
+                const incluirOcupado = USER_ROLE === 'aluno';
+                loadAgendaSection(aluno, incluirOcupado);
             } else if (section === "meus-treinos") {
                 const { loadMeusTreinos } = await import("./treinos.js");
                 loadMeusTreinos();


### PR DESCRIPTION
## Summary
- allow students to request personal's agenda with other events marked as `ocupado`
- show `Ocupado` label in monthly calendar for busy slots
- include busy slots for students when loading agenda

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bce29d7f1483238a32d632f9b1e302