### PR TITLE
feat: add scheduling requests and weekly view

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -595,6 +595,13 @@ body {
     margin-bottom: 10px;
 }
 
+.view-switch {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
 .calendario {
     display: flex;
     flex-direction: column;

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -62,6 +62,10 @@ function loadHomeSection() {
             <button class="quick-btn" data-action="relatorio"><i class="fas fa-chart-line"></i>Relatorio mensal</button>
             <button class="quick-btn" data-action="criar-treino"><i class="fas fa-dumbbell"></i>Criar treino</button>
         </section>
+        <section class="solicitacoes">
+            <h3>Solicitações</h3>
+            <ul id="solicitacoesList"></ul>
+        </section>
         <section class="day-calendar">
             <h3>Agenda de Hoje</h3>
             <div class="calendar-placeholder">Sem atividades por enquanto.</div>
@@ -122,6 +126,37 @@ function loadHomeSection() {
                 alert('Erro ao gerar link.');
             }
         });
+    }
+
+    if (USER_ROLE === 'personal') {
+        try {
+            const res = await fetchWithFreshToken('/api/users/agenda/solicitacoes');
+            const solicitacoes = await res.json();
+            const lista = content.querySelector('#solicitacoesList');
+            if (lista) {
+                if (solicitacoes.length === 0) {
+                    lista.innerHTML = '<li>Sem solicitações</li>';
+                } else {
+                    lista.innerHTML = solicitacoes.map(s =>
+                        `<li data-id="${s.id}">${new Date(s.inicio).toLocaleString('pt-BR')} - ${s.alunoNome || s.alunoEmail} <button class="aceitarSolic">Aceitar</button></li>`
+                    ).join('');
+                    lista.querySelectorAll('.aceitarSolic').forEach(btn => {
+                        btn.addEventListener('click', async e => {
+                            const li = e.target.closest('li');
+                            const id = li.getAttribute('data-id');
+                            await fetchWithFreshToken(`/api/users/agenda/aulas/${id}`, {
+                                method: 'PUT',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ status: 'agendada' })
+                            });
+                            li.remove();
+                        });
+                    });
+                }
+            }
+        } catch (err) {
+            console.error('Erro ao carregar solicitações:', err);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- allow students to request new class slots and mark them as pending
- show pending requests on personal dashboard with ability to accept
- provide weekly agenda view toggle with week as default and add styling for view switch

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf67d7a3c83239f7db247eb453342