### PR TITLE
fix: make home section loader async

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -49,7 +49,7 @@ function loadSection(section) {
     content.innerHTML = `<h2>${capitalize(section)}</h2><p>Conteúdo do módulo "${section}" será carregado aqui...</p>`;
 }
 
-function loadHomeSection() {
+async function loadHomeSection() {
     const content = document.getElementById("content");
     content.innerHTML = `
         <section class="welcome">


### PR DESCRIPTION
## Summary
- declare `loadHomeSection` as async so awaiting inside works

## Testing
- `node --check public/js/dashboard.js` *(fails: Cannot use import statement outside a module)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfb79b9d48323859b9d45c5c7180f