### PR TITLE
Add public anamnese form generation flow

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
     "firebase-admin": "^13.4.0",
     "googleapis": "^105.0.0",
     "googleapis-common": "^7.2.0",
-    "helmet": "^7.0.0"
+    "helmet": "^7.0.0",
+    "nodemailer": "^6.9.13"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/backend/routes/public.js
+++ b/backend/routes/public.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const admin = require('../firebase-admin');
+const { sendMail } = require('../services/mailer');
 
 router.get('/personal/:slug', async (req, res) => {
     const { slug } = req.params;
@@ -16,6 +17,163 @@ router.get('/personal/:slug', async (req, res) => {
     } catch (err) {
         console.error('Erro ao buscar página pública:', err);
         res.status(500).json({ error: 'Erro ao buscar página' });
+    }
+});
+
+router.post('/anamnese-forms', async (req, res) => {
+    const {
+        personalId,
+        formType,
+        nome,
+        email,
+        telefone,
+        dataNascimento,
+        horarioPreferido,
+        preferenciaContato,
+        objetivo,
+        experiencia,
+        restricoes,
+        medicamentos,
+        disponibilidade,
+        alimentacaoAtual,
+        restricoesAlimentares,
+        observacoes
+    } = req.body || {};
+
+    const sanitize = (value) => typeof value === 'string' ? value.trim() : value;
+    const optional = (value) => {
+        const sanitized = sanitize(value);
+        return sanitized ? sanitized : null;
+    };
+
+    const normalizedPersonalId = sanitize(personalId);
+    const sanitizedNome = sanitize(nome);
+    const sanitizedEmail = sanitize(email);
+    const sanitizedEmailLower = sanitizedEmail ? sanitizedEmail.toLowerCase() : null;
+
+    if (!normalizedPersonalId || !sanitizedNome || !sanitizedEmail) {
+        return res.status(400).json({ error: 'Dados obrigatórios não informados.' });
+    }
+
+    const allowedTypes = new Set(['apenas-treino', 'dieta-treino']);
+    const normalizedType = allowedTypes.has(formType) ? formType : 'apenas-treino';
+
+    try {
+        const personalRef = admin.firestore().collection('users').doc(normalizedPersonalId);
+        const personalSnap = await personalRef.get();
+
+        if (!personalSnap.exists) {
+            return res.status(404).json({ error: 'Personal não encontrado.' });
+        }
+
+        const timestamp = new Date().toISOString();
+        const alunosRef = personalRef.collection('alunos');
+
+        let alunoRef = null;
+        let isNew = true;
+
+        let existingDoc = null;
+        if (sanitizedEmail) {
+            const existing = await alunosRef.where('email', '==', sanitizedEmail).limit(1).get();
+            if (!existing.empty) {
+                existingDoc = existing.docs[0];
+            } else if (sanitizedEmailLower) {
+                const existingLower = await alunosRef.where('emailLowerCase', '==', sanitizedEmailLower).limit(1).get();
+                if (!existingLower.empty) {
+                    existingDoc = existingLower.docs[0];
+                }
+            }
+        }
+
+        if (existingDoc) {
+            alunoRef = existingDoc.ref;
+            isNew = false;
+        }
+
+        const alunoPayload = {
+            nome: sanitizedNome,
+            email: sanitizedEmail,
+            origem: 'formulario-anamnese',
+            formularioTipo: normalizedType,
+            atualizadoEm: timestamp
+        };
+
+        if (sanitizedEmailLower) {
+            alunoPayload.emailLowerCase = sanitizedEmailLower;
+        }
+
+        const telefoneSanitizado = optional(telefone);
+        if (telefoneSanitizado) alunoPayload.telefone = telefoneSanitizado;
+        const dataNascSanitizada = optional(dataNascimento);
+        if (dataNascSanitizada) alunoPayload.dataNascimento = dataNascSanitizada;
+        const objetivoSanitizado = optional(objetivo);
+        if (objetivoSanitizado) alunoPayload.objetivo = objetivoSanitizado;
+        const observacoesSanitizadas = optional(observacoes);
+        if (observacoesSanitizadas) alunoPayload.observacoes = observacoesSanitizadas;
+
+        const anamneseBasica = {
+            disponibilidade: optional(disponibilidade),
+            experiencia: optional(experiencia),
+            restricoes: optional(restricoes),
+            medicamentos: optional(medicamentos),
+            horarioPreferido: optional(horarioPreferido),
+            preferenciaContato: optional(preferenciaContato),
+            alimentacaoAtual: optional(alimentacaoAtual),
+            restricoesAlimentares: optional(restricoesAlimentares)
+        };
+
+        Object.keys(anamneseBasica).forEach((key) => {
+            if (!anamneseBasica[key]) {
+                delete anamneseBasica[key];
+            }
+        });
+
+        if (Object.keys(anamneseBasica).length > 0) {
+            alunoPayload.anamneseBasica = anamneseBasica;
+        }
+
+        if (isNew) {
+            alunoPayload.criadoEm = timestamp;
+            alunoPayload.aulasPorSemana = 2;
+            alunoRef = await alunosRef.add(alunoPayload);
+        } else {
+            await alunoRef.set(alunoPayload, { merge: true });
+        }
+
+        const personalData = personalSnap.data() || {};
+        const personalEmail = personalData.email ? String(personalData.email).trim() : null;
+        const personalNome = personalData.nome || '';
+        const formLabel = normalizedType === 'dieta-treino' ? 'dieta e treino' : 'apenas treino';
+
+        if (personalEmail) {
+            const textMessage = `Olá ${personalNome || 'personal'},\n\n` +
+                `${sanitizedNome} acabou de preencher o formulário de anamnese (${formLabel}).\n` +
+                `E-mail: ${sanitizedEmail}\n` +
+                `Telefone: ${telefoneSanitizado || 'não informado'}.\n\n` +
+                `Acesse o painel do PersonalHub para consultar os detalhes.`;
+
+            const htmlMessage = `<p>Olá ${personalNome || 'personal'},</p>` +
+                `<p><strong>${sanitizedNome}</strong> acabou de preencher o formulário de anamnese (${formLabel}).</p>` +
+                `<p><strong>E-mail:</strong> ${sanitizedEmail}<br />` +
+                `<strong>Telefone:</strong> ${telefoneSanitizado || 'não informado'}</p>` +
+                `<p>Acesse o painel do PersonalHub para visualizar todos os detalhes.</p>`;
+
+            try {
+                await sendMail({
+                    to: personalEmail,
+                    subject: 'Novo aluno cadastrado via formulário de anamnese',
+                    text: textMessage,
+                    html: htmlMessage
+                });
+            } catch (emailErr) {
+                console.error('Erro ao enviar notificação por email:', emailErr);
+            }
+        }
+
+        return res.status(201).json({ message: 'Formulário enviado com sucesso.' });
+    } catch (err) {
+        console.error('Erro ao processar formulário de anamnese público:', err);
+        return res.status(500).json({ error: 'Erro ao enviar formulário.' });
     }
 });
 

--- a/backend/services/mailer.js
+++ b/backend/services/mailer.js
@@ -1,0 +1,54 @@
+const nodemailer = require('nodemailer');
+
+let transporter;
+
+function buildTransporter() {
+    const {
+        SMTP_HOST,
+        SMTP_PORT,
+        SMTP_USER,
+        SMTP_PASS,
+        SMTP_SECURE
+    } = process.env;
+
+    if (!SMTP_HOST) {
+        return null;
+    }
+
+    const port = Number(SMTP_PORT || 587);
+    const secure = SMTP_SECURE === 'true' || port === 465;
+
+    const auth = SMTP_USER ? { user: SMTP_USER, pass: SMTP_PASS } : undefined;
+
+    return nodemailer.createTransport({
+        host: SMTP_HOST,
+        port,
+        secure,
+        auth
+    });
+}
+
+async function getTransporter() {
+    if (!transporter) {
+        transporter = buildTransporter();
+    }
+    return transporter;
+}
+
+async function sendMail(options) {
+    const mailer = await getTransporter();
+    if (!mailer) {
+        console.warn('Serviço de email não configurado. Defina as variáveis SMTP_HOST, SMTP_PORT, SMTP_USER e SMTP_PASS.');
+        return false;
+    }
+
+    const from = options.from || process.env.SMTP_FROM || process.env.SMTP_USER;
+    const mailOptions = { ...options, from };
+
+    await mailer.sendMail(mailOptions);
+    return true;
+}
+
+module.exports = {
+    sendMail
+};

--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -349,6 +349,46 @@ body {
     min-width: 280px;
 }
 
+.modal-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.modal-link-container {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.modal-link-row {
+    display: flex;
+    gap: 10px;
+}
+
+.modal-link-input {
+    flex: 1;
+    background-color: #111;
+    border: 1px solid #333;
+    border-radius: 4px;
+    padding: 8px;
+    color: #fff;
+}
+
+.modal-link-actions {
+    display: flex;
+    gap: 10px;
+}
+
+.modal-feedback {
+    font-size: 0.875rem;
+    color: #7bd88f;
+}
+
+.modal-feedback.error {
+    color: #ff6b6b;
+}
+
 /* === Avaliação / Anamnese === */
 .avaliacao-container {
     background-color: #1e1e1e;
@@ -543,6 +583,15 @@ body {
     transition: background 0.2s;
 }
 
+.quick-btn.secondary {
+    background-color: #2a2a2a;
+    border-color: #444;
+}
+
+.quick-btn.secondary:hover {
+    background-color: #353535;
+}
+
 .quick-btn i {
     font-size: 24px;
     color: #f58725;
@@ -550,6 +599,13 @@ body {
 
 .quick-btn:hover {
     background-color: #2a2a2a;
+}
+
+.alunos-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 15px;
 }
 
 .day-calendar,

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -236,3 +236,120 @@ select:focus {
     gap: 20px;
     margin-top: 20px;
 }
+
+/* ===== Formulário público de anamnese ===== */
+body.formulario-anamnese {
+    display: block;
+    min-height: 100vh;
+    padding: 40px 16px;
+    box-sizing: border-box;
+}
+
+.anamnese-public-wrapper {
+    max-width: 840px;
+    margin: 0 auto;
+    background-color: #1e1e1e;
+    padding: 32px;
+    border-radius: 8px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+.anamnese-public-header {
+    text-align: center;
+    margin-bottom: 24px;
+}
+
+.anamnese-public-header h1 {
+    margin-bottom: 8px;
+}
+
+.anamnese-public-header h2 {
+    margin: 0 0 8px;
+}
+
+.anamnese-public-header p {
+    margin: 0;
+}
+
+.anamnese-public-form {
+    display: grid;
+    gap: 20px;
+}
+
+.anamnese-group {
+    border: 1px solid #333;
+    border-radius: 6px;
+    padding: 16px;
+    display: grid;
+    gap: 12px;
+}
+
+.anamnese-group legend {
+    padding: 0 8px;
+    font-weight: 600;
+    color: #f58725;
+}
+
+.anamnese-group label {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    font-size: 0.95rem;
+    gap: 6px;
+    text-align: left;
+}
+
+.anamnese-group label input,
+.anamnese-group label select,
+.anamnese-group label textarea {
+    width: 100%;
+    margin: 0;
+}
+
+.anamnese-group textarea {
+    min-height: 90px;
+    resize: vertical;
+}
+
+.anamnese-group .wide {
+    grid-column: 1 / -1;
+}
+
+.anamnese-submit {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.form-message {
+    margin-top: 20px;
+    text-align: left;
+    font-size: 0.95rem;
+}
+
+.form-message.success {
+    color: #7bd88f;
+}
+
+.form-message.error {
+    color: #ff6b6b;
+}
+
+@media (min-width: 768px) {
+    .anamnese-public-form {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .anamnese-group {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 520px) {
+    body.formulario-anamnese {
+        padding: 24px 12px;
+    }
+
+    .anamnese-public-wrapper {
+        padding: 24px;
+    }
+}

--- a/public/formulario_anamnese.html
+++ b/public/formulario_anamnese.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Formulário de Anamnese | PersonalHub</title>
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/dashboard.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/public/img/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/public/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/public/img/favicon-16x16.png">
+    <link rel="manifest" href="/public/img/site.webmanifest">
+</head>
+<body class="formulario-anamnese">
+    <div class="anamnese-public-wrapper">
+        <header class="anamnese-public-header">
+            <h1><span style="color: #f58725;">Personal</span>Hub</h1>
+            <h2 id="formTitle">Formulário de anamnese</h2>
+            <p id="formSubtitle">Preencha seus dados para que possamos iniciar seu acompanhamento.</p>
+        </header>
+        <form id="newAnamneseForm" class="anamnese-public-form">
+            <fieldset class="anamnese-group">
+                <legend>Informações de contato</legend>
+                <label>
+                    Nome completo
+                    <input type="text" name="nome" placeholder="Seu nome" required />
+                </label>
+                <label>
+                    E-mail
+                    <input type="email" name="email" placeholder="seuemail@email.com" required />
+                </label>
+                <label>
+                    Telefone
+                    <input type="tel" name="telefone" placeholder="(00) 90000-0000" />
+                </label>
+                <label>
+                    Data de nascimento
+                    <input type="date" name="dataNascimento" />
+                </label>
+                <label>
+                    Melhor horário para contato
+                    <input type="text" name="horarioPreferido" placeholder="Ex.: Manhã, tarde ou noite" />
+                </label>
+                <label>
+                    Preferência de contato
+                    <select name="preferenciaContato">
+                        <option value="">Selecione</option>
+                        <option value="whatsapp">WhatsApp</option>
+                        <option value="email">E-mail</option>
+                        <option value="ligacao">Ligação</option>
+                    </select>
+                </label>
+            </fieldset>
+
+            <fieldset class="anamnese-group">
+                <legend>Objetivos e histórico</legend>
+                <label class="wide">
+                    Objetivo principal
+                    <textarea name="objetivo" placeholder="Conte-nos seu principal objetivo."></textarea>
+                </label>
+                <label class="wide">
+                    Experiência com atividades físicas
+                    <textarea name="experiencia" placeholder="Já praticou alguma atividade? Conte como foi."></textarea>
+                </label>
+                <label class="wide">
+                    Há alguma restrição ou lesão?
+                    <textarea name="restricoes" placeholder="Informe restrições médicas, lesões ou dores atuais."></textarea>
+                </label>
+                <label class="wide">
+                    Faz uso de medicamentos?
+                    <textarea name="medicamentos" placeholder="Liste os medicamentos que utiliza atualmente."></textarea>
+                </label>
+                <label class="wide">
+                    Disponibilidade semanal para treinar
+                    <textarea name="disponibilidade" placeholder="Quantos dias e horários tem disponíveis na semana."></textarea>
+                </label>
+            </fieldset>
+
+            <fieldset id="nutritionGroup" class="anamnese-group hidden">
+                <legend>Informações sobre alimentação</legend>
+                <label class="wide">
+                    Como está sua alimentação atualmente?
+                    <textarea name="alimentacaoAtual" placeholder="Descreva sua rotina alimentar."></textarea>
+                </label>
+                <label class="wide">
+                    Possui restrições ou preferências alimentares?
+                    <textarea name="restricoesAlimentares" placeholder="Informe restrições, alergias ou preferências."></textarea>
+                </label>
+            </fieldset>
+
+            <fieldset class="anamnese-group">
+                <legend>Informações adicionais</legend>
+                <label class="wide">
+                    Observações
+                    <textarea name="observacoes" placeholder="Compartilhe outras informações importantes."></textarea>
+                </label>
+            </fieldset>
+
+            <div class="anamnese-submit">
+                <button type="submit" id="submitButton">Enviar formulário</button>
+            </div>
+        </form>
+        <div id="formMessage" class="form-message" role="status"></div>
+    </div>
+
+    <script type="module">
+        const params = new URLSearchParams(window.location.search);
+        const personalId = params.get('personalId');
+        const rawType = params.get('type') || 'apenas-treino';
+        const personalName = params.get('personalName');
+        const typeLabels = {
+            'apenas-treino': 'Apenas treino',
+            'dieta-treino': 'Dieta e treino'
+        };
+
+        const normalizedType = typeLabels[rawType] ? rawType : 'apenas-treino';
+        const selectedLabel = typeLabels[normalizedType];
+
+        const formTitle = document.getElementById('formTitle');
+        const subtitle = document.getElementById('formSubtitle');
+        const nutritionGroup = document.getElementById('nutritionGroup');
+        const form = document.getElementById('newAnamneseForm');
+        const messageBox = document.getElementById('formMessage');
+        const submitButton = document.getElementById('submitButton');
+
+        formTitle.textContent = `Formulário de anamnese - ${selectedLabel}`;
+        if (personalName) {
+            subtitle.textContent = `Este formulário será enviado diretamente para ${personalName}.`;
+        }
+
+        if (normalizedType === 'dieta-treino') {
+            nutritionGroup.classList.remove('hidden');
+        }
+
+        if (!personalId) {
+            form.classList.add('hidden');
+            submitButton?.setAttribute('disabled', 'disabled');
+            messageBox.classList.add('error');
+            messageBox.textContent = 'Link inválido. Solicite um novo formulário ao seu personal.';
+        }
+
+        const showMessage = (text, type = 'info') => {
+            messageBox.textContent = text;
+            messageBox.classList.remove('error', 'success');
+            if (type === 'error') {
+                messageBox.classList.add('error');
+            }
+            if (type === 'success') {
+                messageBox.classList.add('success');
+            }
+        };
+
+        const toggleSubmitting = (isSubmitting) => {
+            if (!submitButton) return;
+            submitButton.disabled = isSubmitting;
+            submitButton.setAttribute('aria-busy', String(isSubmitting));
+            submitButton.textContent = isSubmitting ? 'Enviando...' : 'Enviar formulário';
+        };
+
+        form?.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            if (!personalId) return;
+
+            const formData = new FormData(form);
+            const payload = Object.fromEntries(formData.entries());
+            payload.personalId = personalId;
+            payload.formType = normalizedType;
+
+            toggleSubmitting(true);
+            showMessage('Enviando suas informações...');
+
+            try {
+                const response = await fetch('/api/public/anamnese-forms', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => ({}));
+                    throw new Error(errorData.error || 'Não foi possível enviar o formulário.');
+                }
+
+                showMessage('Recebemos suas informações! Em breve o personal entrará em contato.', 'success');
+                form.reset();
+                form.classList.add('hidden');
+            } catch (err) {
+                console.error('Erro ao enviar formulário de anamnese:', err);
+                showMessage(err.message || 'Não foi possível enviar o formulário. Tente novamente mais tarde.', 'error');
+            } finally {
+                toggleSubmitting(false);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -109,3 +109,7 @@ export async function fetchUserInfo() {
     if (!res.ok) return null;
     return await res.json();
 }
+
+export async function getCurrentUser() {
+    return await waitForUser();
+}


### PR DESCRIPTION
## Summary
- add a "Gerar formulário de anamnese" action in the alunos dashboard to generate shareable links for students
- create a public anamnese form page that captures contato, histórico e alimentação conforme o tipo escolhido
- process public submissions by creating/atualizando o aluno e disparando email de notificação via SMTP configurável

## Testing
- npm install *(fails: 403 Forbidden when downloading dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf22a9fe04832380e4b9978ee74bff