### PR TITLE
Adjust anamnese layout to single column

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -336,11 +336,11 @@ body.formulario-anamnese {
 
 @media (min-width: 768px) {
     .anamnese-public-form {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-columns: 1fr;
     }
 
     .anamnese-group {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 }
 


### PR DESCRIPTION
## Summary
- update the anamnese form grid to keep all fieldset groups in a single column
- allow questions inside each fieldset to flow across up to three columns on wider screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf305368088323beb37b852263b3c8