### PR TITLE
Fix anamnese group layout and restore hidden sections

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -272,7 +272,8 @@ body.formulario-anamnese {
 }
 
 .anamnese-public-form {
-    display: grid;
+    display: flex;
+    flex-direction: column;
     gap: 20px;
 }
 
@@ -281,6 +282,7 @@ body.formulario-anamnese {
     border-radius: 6px;
     padding: 16px;
     display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 12px;
 }
 
@@ -334,16 +336,6 @@ body.formulario-anamnese {
     color: #ff6b6b;
 }
 
-@media (min-width: 768px) {
-    .anamnese-public-form {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .anamnese-group {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-}
-
 @media (max-width: 520px) {
     body.formulario-anamnese {
         padding: 24px 12px;
@@ -351,5 +343,9 @@ body.formulario-anamnese {
 
     .anamnese-public-wrapper {
         padding: 24px;
+    }
+
+    .anamnese-group {
+        grid-template-columns: 1fr;
     }
 }

--- a/public/formulario_anamnese.html
+++ b/public/formulario_anamnese.html
@@ -54,6 +54,7 @@
                         <option value="whatsapp">WhatsApp</option>
                         <option value="indicado">Indicação de amigo</option>
                         <option value="outro">Outro</option>
+                    </select>
                 </label>
             </fieldset>
 
@@ -92,7 +93,6 @@
                     <textarea name="restricoesAlimentares" placeholder="Informe restrições, alergias ou preferências."></textarea>
                 </label>
             </fieldset>
-
             <fieldset class="anamnese-group">
                 <legend>Informações adicionais</legend>
                 <label class="wide">


### PR DESCRIPTION
## Summary
- update the anamnese form container to stack groups vertically while allowing up to three questions per row
- add the missing closing tag in the public anamnese form so every question group remains visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf305368088323beb37b852263b3c8