### PR TITLE
Atualiza tabela de alunos com vencimento e exclusão em massa

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -333,6 +333,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
+    z-index: 1000;
 }
 
 .modal.hidden {
@@ -378,6 +379,41 @@ body {
 .modal-link-actions {
     display: flex;
     gap: 10px;
+}
+
+.form-field.status-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.status-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.status-button {
+    padding: 0.5rem 1.25rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-color, #2a2a2a);
+    background: rgba(255, 255, 255, 0.04);
+    color: inherit;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.status-button:hover,
+.status-button:focus-visible {
+    background: rgba(245, 135, 37, 0.15);
+    border-color: rgba(245, 135, 37, 0.65);
+    outline: none;
+}
+
+.status-button.active {
+    background: #f58725;
+    color: #000;
+    border-color: #f58725;
 }
 
 .modal-feedback {

--- a/public/js/alunos.js
+++ b/public/js/alunos.js
@@ -395,6 +395,14 @@ function showEditAlunoForm(aluno) {
             || PLAN_OPTIONS.find(opt => opt.nome === aluno.plano.nome && opt.duracao === aluno.plano.duracao)
         : null;
     const selectedPlanId = matchingPlan?.id || '';
+    const statusNormalized = (aluno.status || '').toString().toLowerCase();
+    const initialStatus = statusNormalized === 'inativo' ? 'inativo'
+        : statusNormalized === 'ativo' ? 'ativo'
+            : statusNormalized === 'pendente' ? 'pendente' : 'ativo';
+    const isStatusActive = initialStatus === 'ativo';
+    const isStatusInactive = initialStatus === 'inativo';
+    const statusLabel = aluno.statusLabel || aluno.status || '';
+
     const planOptionsHtml = PLAN_OPTIONS.map(option => `
                 <option value="${option.id}" ${option.id === selectedPlanId ? 'selected' : ''}>
                     ${option.nome} - ${option.duracao} - ${option.preco}
@@ -413,6 +421,15 @@ function showEditAlunoForm(aluno) {
             <div class="form-field">
                 <label for="editAlunoTelefone">Telefone</label>
                 <input id="editAlunoTelefone" type="text" name="telefone" value="${aluno.telefone || ''}" />
+            </div>
+            <div class="form-field status-field">
+                <span>Status</span>
+                <div class="status-buttons" role="group" aria-label="Status do aluno">
+                    <button type="button" class="status-button${isStatusActive ? ' active' : ''}" data-status="ativo">Ativo</button>
+                    <button type="button" class="status-button${isStatusInactive ? ' active' : ''}" data-status="inativo">Inativo</button>
+                </div>
+                <input type="hidden" name="status" value="${initialStatus}" />
+                ${initialStatus !== 'ativo' && initialStatus !== 'inativo' && statusLabel ? `<small>Status atual: ${statusLabel}</small>` : ''}
             </div>
             <div class="form-field">
                 <label for="editAlunoDataNascimento">Data de nascimento</label>
@@ -474,6 +491,17 @@ function showEditAlunoForm(aluno) {
     const planInfo = form.querySelector('[data-plan-info]');
     const inicioPlanoInput = form.querySelector('#editAlunoInicioPlano');
     const vencimentoPlanoInput = form.querySelector('#editAlunoVencimentoPlano');
+    const statusInput = form.querySelector('input[name="status"]');
+    const statusButtons = form.querySelectorAll('.status-button');
+
+    statusButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            const value = button.dataset.status;
+            if (!value || !statusInput) return;
+            statusInput.value = value;
+            statusButtons.forEach(btn => btn.classList.toggle('active', btn === button));
+        });
+    });
 
     const updatePlanDetails = (shouldCalculateEnd = false, { ensureStartDate = false } = {}) => {
         const selectedPlan = PLAN_OPTIONS.find(opt => opt.id === planSelect.value);
@@ -524,7 +552,8 @@ function showEditAlunoForm(aluno) {
             metas: form.metas.value,
             prazoMeta: form.prazoMeta.value,
             motivacao: form.motivacao.value,
-            observacoes: form.observacoes.value
+            observacoes: form.observacoes.value,
+            status: statusInput?.value || initialStatus || 'ativo'
         };
         const planoSelecionado = PLAN_OPTIONS.find(opt => opt.id === form.plano.value);
         data.plano = planoSelecionado ? {

--- a/tests/studentsTableInteractions.test.mjs
+++ b/tests/studentsTableInteractions.test.mjs
@@ -16,10 +16,12 @@ const PLAN_LABELS = {
 function createDataset(count = 60) {
     return Array.from({ length: count }, (_, index) => {
         const statusKeys = Object.keys(STATUS_LABELS);
-        const planKeys = Object.keys(PLAN_LABELS);
+        const planKeys = ["mensal", "trimestral", "semestral"];
         const status = statusKeys[index % statusKeys.length];
         const plan = planKeys[index % planKeys.length];
         const base = new Date(Date.UTC(2024, 0, 1 + index));
+        const dueDate = new Date(base.getTime() + 30 * 24 * 60 * 60 * 1000);
+        const startDate = new Date(base.getTime() - 30 * 24 * 60 * 60 * 1000);
         return {
             id: `mock-${index + 1}`,
             name: `Aluno ${index + 1}`,
@@ -28,9 +30,12 @@ function createDataset(count = 60) {
             statusLabel: STATUS_LABELS[status],
             plan,
             planLabel: PLAN_LABELS[plan],
+            planDisplay: PLAN_LABELS[plan],
+            planFilters: [plan],
             joinedAt: base.toISOString(),
             lastActivity: new Date(base.getTime() + 2_592_000).toISOString(),
-            lastSession: new Date(base.getTime() + 86_400_000).toISOString(),
+            planStart: startDate.toISOString(),
+            planDueDate: dueDate.toISOString(),
             avatar: ""
         };
     });


### PR DESCRIPTION
## Summary
- ajusta a tabela de alunos para exibir o plano real e o vencimento baseado nos dados de cadastro, além de adicionar a ação de exclusão em massa
- melhora o formulário de edição com controles de status ativo/inativo e corrige a sobreposição de modais com o cabeçalho fixo
- atualiza o provedor e os testes para suportar os novos campos de plano e vencimento

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d064a80fcc8323ac983d0540f5a228