### PR TITLE
Fix dashboard content padding on narrow screens

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -103,6 +103,7 @@ body {
     max-width: 1400px;
     margin: 0 auto;
     width: 100%;
+    box-sizing: border-box;
 }
 
 .sidebar ul li {


### PR DESCRIPTION
## Summary
- ensure the dashboard content container keeps its padding within the available width by using border-box sizing

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d446046c388323b96dd825eef28c68