### PR TITLE
Show student avatar and metadata in new evaluation header

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -181,7 +181,9 @@ select:focus {
     padding: 10px 20px;
     display: flex;
     align-items: center;
-    gap: 10px;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
     box-shadow: 0 2px 6px rgba(0,0,0,0.5);
     z-index: 100;
 }
@@ -189,6 +191,23 @@ select:focus {
 .page-header h2 {
     margin: 0;
     font-size: 20px;
+}
+
+.header-aluno {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-left: auto;
+}
+
+.header-aluno .dados-aluno h3 {
+    margin: 0 0 4px;
+}
+
+.dados-aluno-meta {
+    margin: 0;
+    font-size: 14px;
+    color: #cfcfcf;
 }
 
 .back-btn {
@@ -207,8 +226,9 @@ select:focus {
 
 .aluno-info {
     display: flex;
-    align-items: center;
-    gap: 20px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
     margin-bottom: 20px;
     background-color: #1e1e1e;
     padding: 20px;
@@ -222,12 +242,26 @@ select:focus {
     border-radius: 50%;
 }
 
-.dados-aluno h3 {
-    margin: 0 0 5px;
+.aluno-info label {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
 }
 
-.dados-aluno input[type="date"] {
-    width: auto;
+.aluno-info input[type="date"] {
+    width: 100%;
+}
+
+@media (max-width: 600px) {
+    .header-aluno {
+        width: 100%;
+        justify-content: flex-start;
+    }
+
+    .header-aluno .dados-aluno h3 {
+        font-size: 16px;
+    }
 }
 
 .avaliacao-actions {

--- a/public/img/avatar-female.svg
+++ b/public/img/avatar-female.svg
@@ -1,0 +1,7 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="120" rx="60" fill="#713E6F"/>
+  <circle cx="60" cy="44" r="24" fill="#F6E8F4"/>
+  <path d="M28 104c2-20 16-36 32-36s30 16 32 36" fill="#F6E8F4"/>
+  <path d="M44 54c4 6 9 10 16 10s12-4 16-10" stroke="#713E6F" stroke-width="4" stroke-linecap="round"/>
+  <path d="M44 28c4-6 10-10 16-10s12 4 16 10c3 4 5 9 5 14 0 12-9 22-21 22s-21-10-21-22c0-5 2-10 5-14z" fill="#F6E8F4"/>
+</svg>

--- a/public/img/avatar-male.svg
+++ b/public/img/avatar-male.svg
@@ -1,0 +1,7 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="120" rx="60" fill="#2F4F6F"/>
+  <circle cx="60" cy="44" r="24" fill="#E6EDF7"/>
+  <path d="M28 104c0-20.435 14.327-37 32-37h0c17.673 0 32 16.565 32 37" fill="#E6EDF7"/>
+  <path d="M68 26c7 2 14 7 14 20 0 8-4 16-8 18" stroke="#2F4F6F" stroke-width="4" stroke-linecap="round"/>
+  <path d="M52 26c-7 2-14 7-14 20 0 8 4 16 8 18" stroke="#2F4F6F" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/public/js/novaAvaliacao.js
+++ b/public/js/novaAvaliacao.js
@@ -8,13 +8,26 @@ async function carregarCabecalho(id) {
         if (res.ok) {
             const aluno = await res.json();
             const nomeEl = document.getElementById('nomeAluno');
-            const idadeEl = document.getElementById('idadeAluno');
-            const sexoEl = document.getElementById('sexoAluno');
+            const metaEl = document.getElementById('metaAluno');
             const fotoEl = document.getElementById('fotoAluno');
             if (nomeEl) nomeEl.textContent = aluno.nome || '';
-            if (idadeEl && aluno.idade) idadeEl.textContent = `${aluno.idade} anos`;
-            if (sexoEl && aluno.sexo) sexoEl.textContent = aluno.sexo;
-            if (fotoEl && aluno.fotoUrl) fotoEl.src = aluno.fotoUrl;
+            if (metaEl) {
+                const metaParts = [];
+                if (aluno.idade) metaParts.push(`${aluno.idade} anos`);
+                if (aluno.sexo) metaParts.push(aluno.sexo);
+                metaEl.textContent = metaParts.join(' • ');
+            }
+            if (fotoEl) {
+                const genero = (aluno.sexo || '').toString().toLowerCase();
+                const feminino = genero.startsWith('f');
+                const defaultFoto = feminino ? './img/avatar-female.svg' : './img/avatar-male.svg';
+                const fotoSrc = aluno.fotoUrl || defaultFoto;
+                fotoEl.src = fotoSrc;
+                fotoEl.alt = aluno.nome ? `Foto de ${aluno.nome}` : 'Foto do aluno';
+                fotoEl.addEventListener('error', () => {
+                    fotoEl.src = defaultFoto;
+                }, { once: true });
+            }
         }
     } catch (err) {
         console.error('Erro ao carregar aluno', err);

--- a/public/nova_avaliacao.html
+++ b/public/nova_avaliacao.html
@@ -16,19 +16,25 @@
 <body>
     <header class="page-header">
         <h2>Nova Avaliação</h2>
+        <div class="header-aluno">
+            <img
+                id="fotoAluno"
+                class="foto-aluno"
+                src="./img/avatar-male.svg"
+                alt="Foto do aluno"
+            />
+            <div class="dados-aluno">
+                <h3 id="nomeAluno"></h3>
+                <p id="metaAluno" class="dados-aluno-meta"></p>
+            </div>
+        </div>
     </header>
     <main class="avaliacao-main">
         <section id="alunoInfo" class="aluno-info">
-            <img id="fotoAluno" class="foto-aluno" src="" alt="Foto do aluno" />
-            <div class="dados-aluno">
-                <h3 id="nomeAluno"></h3>
-                <p id="idadeAluno"></p>
-                <p id="sexoAluno"></p>
-                <label>
-                    Data da próxima avaliação
-                    <input type="date" id="proximaAvaliacao" />
-                </label>
-            </div>
+            <label>
+                Data da próxima avaliação
+                <input type="date" id="proximaAvaliacao" />
+            </label>
         </section>
         <section id="avaliacaoOpcoes" class="opcoes-avaliacao"></section>
         <div class="avaliacao-actions">


### PR DESCRIPTION
## Summary
- display the student's name, age, gender, and photo directly in the new evaluation header
- add male and female default avatar assets and fallback logic for missing photos
- adjust header and evaluation layout styling to accommodate the new information

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e56c8971e083238533e39766060e74