### PR TITLE
Fix header overlap by syncing main offset with header height

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -172,6 +172,10 @@ select:focus {
     background-color: #2e2e2e;
 }
 /* ===== Nova Avaliacao ===== */
+:root {
+    --page-header-offset: 100px;
+}
+
 .page-header {
     position: fixed;
     top: 0;
@@ -220,7 +224,8 @@ select:focus {
 
 .avaliacao-main {
     max-width: 1200px;
-    margin: 80px auto 0;
+    margin: 100px auto 0;
+    margin-top: var(--page-header-offset, 100px);
     padding: 20px;
 }
 

--- a/public/js/novaAvaliacao.js
+++ b/public/js/novaAvaliacao.js
@@ -1,6 +1,13 @@
 import { getAlunoId, renderOpcoes } from './avaliacao.js';
 import { fetchWithFreshToken } from './auth.js';
 
+function updateMainOffset() {
+    const header = document.querySelector('.page-header');
+    if (!header) return;
+    const offset = header.getBoundingClientRect().height + 20;
+    document.documentElement.style.setProperty('--page-header-offset', `${offset}px`);
+}
+
 async function carregarCabecalho(id) {
     if (!id) return;
     try {
@@ -28,6 +35,7 @@ async function carregarCabecalho(id) {
                     fotoEl.src = defaultFoto;
                 }, { once: true });
             }
+            updateMainOffset();
         }
     } catch (err) {
         console.error('Erro ao carregar aluno', err);
@@ -38,6 +46,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const id = getAlunoId();
     carregarCabecalho(id);
     renderOpcoes(id, 'avaliacaoOpcoes');
+
+    updateMainOffset();
+    window.addEventListener('resize', updateMainOffset);
+
+    const header = document.querySelector('.page-header');
+    if (header && 'ResizeObserver' in window) {
+        const observer = new ResizeObserver(() => updateMainOffset());
+        observer.observe(header);
+    }
 
     // cria/recupera id da avaliacao em andamento
     let avalId = localStorage.getItem(`currentAvalId_${id}`);


### PR DESCRIPTION
## Summary
- add a CSS custom property for the evaluation page main offset with a safer default
- dynamically update the offset based on the fixed header height to prevent overlap

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5709226a88323b8b1e255756e35a0